### PR TITLE
fixed failing holiday model tests

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151215145322) do
+ActiveRecord::Schema.define(version: 20151215181135) do
 
   create_table "chair_wimis", force: :cascade do |t|
     t.boolean "admin",          default: false
@@ -50,11 +50,14 @@ ActiveRecord::Schema.define(version: 20151215145322) do
 
   create_table "holidays", force: :cascade do |t|
     t.integer  "user_id"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.date     "start"
     t.date     "end"
-    t.integer  "status",     default: 0
+    t.string   "reason"
+    t.string   "annotation"
+    t.integer  "replacement_user_id"
+    t.integer  "status",              default: 0
   end
 
   add_index "holidays", ["user_id"], name: "index_holidays_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151215181135) do
+ActiveRecord::Schema.define(version: 20151215145322) do
 
   create_table "chair_wimis", force: :cascade do |t|
     t.boolean "admin",          default: false
@@ -50,14 +50,11 @@ ActiveRecord::Schema.define(version: 20151215181135) do
 
   create_table "holidays", force: :cascade do |t|
     t.integer  "user_id"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
     t.date     "start"
     t.date     "end"
-    t.string   "reason"
-    t.string   "annotation"
-    t.integer  "replacement_user_id"
-    t.integer  "status",              default: 0
+    t.integer  "status",     default: 0
   end
 
   add_index "holidays", ["user_id"], name: "index_holidays_on_user_id"

--- a/spec/models/holiday_spec.rb
+++ b/spec/models/holiday_spec.rb
@@ -46,19 +46,33 @@ RSpec.describe Holiday, type: :model do
 
   it "is invalid when not enough leave is left" do
     @user.update_attribute(:remaining_leave, 0)
-    #if Jan 1st isn't a business day this test would fail otherwise
-    enddate = Date.new(Date.today.year + 1, 1, 1)
-    enddate += 1.days until enddate.wday == 1
+    #if Jan 2nd isn't a business day this test would fail otherwise
+    startdate = Date.new(Date.today.year, 12, 31)
+    if startdate.wday == 6 || startdate.wday == 0
+      startdate -= 1.days until startdate.wday == 5
+    end
+    
+    enddate = Date.new(Date.today.year + 1, 1, 2)
+    if enddate.wday == 6 || enddate.wday == 0
+      enddate += 1.days until enddate.wday == 1
+    end
 
     expect(FactoryGirl.build(:holiday, user_id: @user.id, start: Date.new(Date.today.year, 12, 31), end: enddate)).to_not be_valid
   end
 
   it "returns the duration" do
-    #if Jan 1st isn't a business day this test would fail otherwise
-    enddate = Date.new(Date.today.year + 1, 1, 1)
-    enddate += 1.days until enddate.wday == 1
+    #if Jan 2nd isn't a business day this test would fail otherwise
+    startdate = Date.new(Date.today.year, 12, 31)
+    if startdate.wday == 6 || startdate.wday == 0
+      startdate -= 1.days until startdate.wday == 5
+    end
 
-    holiday = FactoryGirl.create(:holiday, user_id: @user.id, start: Date.new(Date.today.year, 12, 31), end: enddate)
-    expect(holiday.duration).to eq(1)
+    enddate = Date.new(Date.today.year + 1, 1, 2)
+    if enddate.wday == 6 || enddate.wday == 0
+      enddate += 1.days until enddate.wday == 1
+    end
+
+    holiday = FactoryGirl.create(:holiday, user_id: @user.id, start: startdate, end: enddate)
+    expect(holiday.duration).to eq(2)
   end
 end

--- a/spec/models/holiday_spec.rb
+++ b/spec/models/holiday_spec.rb
@@ -46,11 +46,19 @@ RSpec.describe Holiday, type: :model do
 
   it "is invalid when not enough leave is left" do
     @user.update_attribute(:remaining_leave, 0)
-    expect(FactoryGirl.build(:holiday, user_id: @user.id, start: Date.new(Date.today.year, 12, 31), end: Date.new(Date.today.year + 1, 1,1))).to_not be_valid
+    #if Jan 1st isn't a business day this test would fail otherwise
+    enddate = Date.new(Date.today.year + 1, 1, 1)
+    enddate += 1.days until enddate.wday == 1
+
+    expect(FactoryGirl.build(:holiday, user_id: @user.id, start: Date.new(Date.today.year, 12, 31), end: enddate)).to_not be_valid
   end
 
   it "returns the duration" do
-    holiday = FactoryGirl.create(:holiday, user_id: @user.id, start: Date.new(Date.today.year, 12, 31), end: Date.new(Date.today.year + 1, 1, 1))
+    #if Jan 1st isn't a business day this test would fail otherwise
+    enddate = Date.new(Date.today.year + 1, 1, 1)
+    enddate += 1.days until enddate.wday == 1
+
+    holiday = FactoryGirl.create(:holiday, user_id: @user.id, start: Date.new(Date.today.year, 12, 31), end: enddate)
     expect(holiday.duration).to eq(1)
   end
 end


### PR DESCRIPTION
Dieser PR fixt die fehlschlagenden Tests des Holiday Models.
Das Problem war, dass für beide Tests erwartet wurde, dass die duration vom 31.12. dieses Jahres zum 1.1. des nächsten Jahres 1 ist. Da insbesondere der 1.1.2017 aber ein Sonntag ist, gab es als Ergebnis von business_days_until 0 Tage.
Das Enddatum des Tests ist jetzt der 1. Montag des nächsten Jahres.