### PR TITLE
Fix/users_show localization

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
+      I18n.locale = @user.language
       flash[:success] = t('.user_updated')
       redirect_to current_user
     else

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,7 @@
         <% if (chair = current_user.chair) != nil %>
             <%= chair.name %>
         <% else %>
-            <%= I18n.t('activerecord.attributes.user.not_member_of_chair') %>
+            <%= I18n.t('activerecord.attributes.request.not_member_of_chair') %>
         <% end %>
       </p>
       <p><strong><%= model_class.human_attribute_name(:personnel_number)+": " %></strong><%= current_user.personnel_number %></p>
@@ -37,12 +37,12 @@
 
   <div class="panel panel-default">
     <div class="panel-heading">
-      <h4>Work Times</h4>
+      <h4><%= t 'users.show.work_times' %></h4>
     </div>
     <div class="panel-body">
       <% @user.years_and_months_of_existence.each do |month| %>
         <p>
-          <%= link_to Date::MONTHNAMES[month.last] + " " + month.first.to_s + ":  ", work_days_path(month: month.last, year: month.first)%>
+          <%= link_to t('date.month_names')[month.last] + " " + month.first.to_s + ":  ", work_days_path(month: month.last, year: month.first)%>
           <% current_user.projects_for_month(month.first, month.last).each do |project|%>
             <%= link_to project.title + " ", work_days_path(month: month.last, year: month.first, project: project.id)%>
           <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,7 @@
         <% if (chair = current_user.chair) != nil %>
             <%= chair.name %>
         <% else %>
-            <%= I18n.t('activerecord.attributes.request.not_member_of_chair') %>
+            <%= t('activerecord.attributes.request.not_member_of_chair') %>
         <% end %>
       </p>
       <p><strong><%= model_class.human_attribute_name(:personnel_number)+": " %></strong><%= current_user.personnel_number %></p>
@@ -37,7 +37,7 @@
 
   <div class="panel panel-default">
     <div class="panel-heading">
-      <h4><%= t 'users.show.work_times' %></h4>
+      <h4><%= t '.work_times' %></h4>
     </div>
     <div class="panel-body">
       <% @user.years_and_months_of_existence.each do |month| %>

--- a/config/locales/de.bootstrap.yml
+++ b/config/locales/de.bootstrap.yml
@@ -105,6 +105,7 @@ de:
       holiday_requests: "Urlaubsanfragen"
       request_holiday: "Urlaub anfragen"
       user_data: "Profilbezogene Daten"
+      work_times: "Arbeitstage"
       remaining_leave: "Verbleibender Resturlaub: %{leave} Tag(e)"
       remaining_leave_last_year: ", davon %{leave_last_year} Tag(e) aus %{last_year}"
       days: "Tag(e)"

--- a/config/locales/de.bootstrap.yml
+++ b/config/locales/de.bootstrap.yml
@@ -105,7 +105,7 @@ de:
       holiday_requests: "Urlaubsanfragen"
       request_holiday: "Urlaub anfragen"
       user_data: "Profilbezogene Daten"
-      work_times: "Arbeitstage"
+      work_times: "Arbeitszeiten"
       remaining_leave: "Verbleibender Resturlaub: %{leave} Tag(e)"
       remaining_leave_last_year: ", davon %{leave_last_year} Tag(e) aus %{last_year}"
       days: "Tag(e)"

--- a/config/locales/en.bootstrap.yml
+++ b/config/locales/en.bootstrap.yml
@@ -114,7 +114,7 @@ en:
       holiday_requests: "Holiday Requests"
       request_holiday: "Request Holiday"
       user_data: "User Data"
-      work_times: "Work Times"
+      work_times: "Working Times"
       remaining_leave: "Remaining Leave: %{leave} Day(s)"
       remaining_leave_last_year: ", thereof %{leave_last_year} Day(s) from %{last_year}"
       title: "User Profile"

--- a/config/locales/en.bootstrap.yml
+++ b/config/locales/en.bootstrap.yml
@@ -114,6 +114,7 @@ en:
       holiday_requests: "Holiday Requests"
       request_holiday: "Request Holiday"
       user_data: "User Data"
+      work_times: "Work Times"
       remaining_leave: "Remaining Leave: %{leave} Day(s)"
       remaining_leave_last_year: ", thereof %{leave_last_year} Day(s) from %{last_year}"
       title: "User Profile"


### PR DESCRIPTION
#242 

Die Anzeige, dass der Nutzer keinem Chair zugeteilt ist, die Arbeitstage, die Monatsnamen und die Nachricht für erfolgreiche Aktualisierung sind jetzt in der richtigen Sprache.