### PR TITLE
fix/215 delete pending applications if user becomes admin or representative

### DIFF
--- a/app/models/chair.rb
+++ b/app/models/chair.rb
@@ -52,6 +52,12 @@ class Chair < ActiveRecord::Base
             success = true
           end
         end
+        if adminApp = ChairWimi.find_by(user: admin, application: 'pending')
+          adminApp.destroy
+        end
+        if repApp = ChairWimi.find_by(user: representative, application: 'pending')
+          repApp.destroy
+        end
       else
         unless admin.is_wimi?
           c = ChairWimi.new(admin: true, representative: true, chair: self, user: admin, application: 'accepted')
@@ -59,6 +65,9 @@ class Chair < ActiveRecord::Base
           if save && c.save
             success = true
           end
+        end
+        if app = ChairWimi.find_by(user: admin, application: 'pending')
+          app.destroy
         end
       end
     end
@@ -89,6 +98,12 @@ class Chair < ActiveRecord::Base
             success = true
           end
         end
+        if adminApp = ChairWimi.find_by(user: admin, application: 'pending')
+          adminApp.destroy
+        end
+        if repApp = ChairWimi.find_by(user: representative, application: 'pending')
+          repApp.destroy
+        end
       else
         unless admin.is_wimi?
           c = ChairWimi.new(admin: true, representative: true, chair: self, user: admin, application: 'accepted')
@@ -96,6 +111,9 @@ class Chair < ActiveRecord::Base
           if save && c.save
             success = true
           end
+        end
+        if app = ChairWimi.find_by(user: admin, application: 'pending')
+          app.destroy
         end
       end
     end

--- a/spec/controllers/chairs_controller_spec.rb
+++ b/spec/controllers/chairs_controller_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe ChairsController, type: :controller do
       expect(Chair.all.count).to eq(chair_count)
     end
 
-    it 'removes pending applications if user becomes admin or representative' do
+    it 'removes pending applications if user becomes admin or representative while creating a chair' do
       superadmin = FactoryGirl.create(:user, superadmin: true)
       user = FactoryGirl.create(:user)
       chair = FactoryGirl.create(:chair)
@@ -265,7 +265,7 @@ RSpec.describe ChairsController, type: :controller do
       expect(Chair.last.representative.user).to eq(@superadmin)
     end
 
-    it 'removes pending applications if user becomes admin or representative' do
+    it 'removes pending applications if user becomes admin or representative while modifying a chair' do
       superadmin = FactoryGirl.create(:user, superadmin: true)
       user = FactoryGirl.create(:user)
       chair = FactoryGirl.create(:chair)

--- a/spec/controllers/chairs_controller_spec.rb
+++ b/spec/controllers/chairs_controller_spec.rb
@@ -189,6 +189,23 @@ RSpec.describe ChairsController, type: :controller do
       post :create, {chair: {name: 'Test'}}
       expect(Chair.all.count).to eq(chair_count)
     end
+
+    it 'removes pending applications if user becomes admin or representative' do
+      superadmin = FactoryGirl.create(:user, superadmin: true)
+      user = FactoryGirl.create(:user)
+      chair = FactoryGirl.create(:chair)
+      chairwimi = FactoryGirl.create(:chair_wimi, user: user, chair: chair, application: 'pending')
+      expect(ChairWimi.find_by(user: user, application: 'pending')).to eq(chairwimi)
+      expect(ChairWimi.find_by(user: user, application: 'accepted')).to eq(nil)
+
+      login_with superadmin
+      expect {
+        post :create, {chair: {name: 'Test'}, admin_user: user, representative_user: user}
+      }.to change(ChairWimi, :count).by(0)
+
+      expect(ChairWimi.find_by(user: user, application: 'pending')).to eq(nil)
+      expect(ChairWimi.find_by(user: user, application: 'accepted')).to_not eq(nil)
+    end
   end
 
   describe 'POST #update' do
@@ -246,6 +263,22 @@ RSpec.describe ChairsController, type: :controller do
       expect(Chair.last.name).to eq('Test')
       expect(Chair.last.admins.count { |admin| (admin.user == @user) }).to eq(1)
       expect(Chair.last.representative.user).to eq(@superadmin)
+    end
+
+    it 'removes pending applications if user becomes admin or representative' do
+      superadmin = FactoryGirl.create(:user, superadmin: true)
+      user = FactoryGirl.create(:user)
+      chair = FactoryGirl.create(:chair)
+      newchair = FactoryGirl.create(:chair)
+      chairwimi = FactoryGirl.create(:chair_wimi, user: user, chair: chair, application: 'pending')
+      expect(ChairWimi.find_by(user: user, application: 'pending')).to eq(chairwimi)
+      expect(ChairWimi.find_by(user: user, application: 'accepted')).to eq(nil)
+
+      login_with superadmin
+      put :update, id: newchair.id, chair: {name: 'NewTest'}, admin_user: user, representative_user: user
+
+      expect(ChairWimi.find_by(user: user, application: 'pending')).to eq(nil)
+      expect(ChairWimi.find_by(user: user, application: 'accepted')).to_not eq(nil)
     end
   end
 


### PR DESCRIPTION
Wenn ein Benutzer eine Bewerbung laufen hat und gleichzeitig zum Admin an einem Lehrstuhl bei der Erstellung von diesem ernannt wird, dann kann er nicht Admin werden, solange die Bewerbung angenommen/abgelehnt wird.

Fix:
- Wenn ein Nutzer mit laufender Bewerbung zum Admin ernannt wird, dann werden seine Bewerbungen verworfen und er wird Admin des entsprechenden Lehrstuhls