### PR TITLE
fix showing of working hours button if user is not part of project

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -43,6 +43,9 @@ class Ability
     can :sign_user_out, Project do |project|
       project.users.include? user
     end
+    can :add_working_hours, Project do |project|
+      project.users.include? user
+    end
     # can :accept_invitation, Project
     # can :manage, Stundenzettel
   end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -16,10 +16,10 @@
   <dd><%= @project.public ? t('.public', default:'Public') : t('.private', default:'private') %></dd>
 </dl>
 
-<% if current_user.is_hiwi? %>
+<% if can? :add_working_hours, @project %>
   <dl class="dl-horizontal">
     <dt><strong><%= t('.working_hours', default:'Working hours') %>:</strong></dt>
-    <dd><%= link_to t('projects.form.add_working_hours', default:'Add working hours'),
+    <dd><%= link_to t('.add_working_hours', default:'Add working hours'),
                     new_work_day_path, class: 'pull-right', style: 'margin-right: 15px' %>
       <div>
         <% current_user.work_year_months_for_project(@project).each do |month| %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -18,8 +18,8 @@
 
 <% if can? :add_working_hours, @project %>
   <dl class="dl-horizontal">
-    <dt><strong><%= t('.working_hours', default:'Working hours') %>:</strong></dt>
-    <dd><%= link_to t('.add_working_hours', default:'Add working hours'),
+    <dt><strong><%= t('.working_hours') %>:</strong></dt>
+    <dd><%= link_to t('.add_working_hours'),
                     new_work_day_path, class: 'pull-right', style: 'margin-right: 15px' %>
       <div>
         <% current_user.work_year_months_for_project(@project).each do |month| %>

--- a/spec/views/projects/show.html.erb_spec.rb
+++ b/spec/views/projects/show.html.erb_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'projects/show', type: :view do
     login_as representative
     project = FactoryGirl.create(:project, chair: representative.chair, status: true)
     representative.projects << project
-    visit project_path(project.id)
+    visit project_path(project)
 
     expect(page).to have_content(project.title)
     expect(page).to have_content(project.chair.name)
@@ -38,7 +38,7 @@ RSpec.describe 'projects/show', type: :view do
     login_as wimi
     project = FactoryGirl.create(:project, chair: wimi.chair, status: true)
     wimi.projects << project
-    visit project_path(project.id)
+    visit project_path(project)
 
     expect(page).to have_content(project.title)
     expect(page).to have_content(project.chair.name)
@@ -54,7 +54,7 @@ RSpec.describe 'projects/show', type: :view do
 
       login_as @hiwi
       @project = FactoryGirl.create(:project, chair: chair_representative.chair, status: true)
-      visit project_path(@project.id)
+      visit project_path(@project)
     end
 
     it 'has information about the project on page' do
@@ -126,7 +126,7 @@ RSpec.describe 'projects/show', type: :view do
     login_as wimi
     project = FactoryGirl.create(:project, chair: wimi.chair, status: true)
     wimi.projects << project
-    visit project_path(project.id)
+    visit project_path(project)
     expect(page).to have_content(I18n.t('projects.form.show_all_working_hours'), count: 1)
   end
 end

--- a/spec/views/projects/show.html.erb_spec.rb
+++ b/spec/views/projects/show.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'projects/show', type: :view do
     @chair = FactoryGirl.create(:chair)
     @wimi = FactoryGirl.create(:chair_representative, user: FactoryGirl.create(:user), chair: @chair).user
 
-    sign_in @user
+    login_as @user
     @project = FactoryGirl.create(:project, chair_id: @wimi.chair.id)
     allow(view).to receive(:current_user).and_return(@user)
   end
@@ -14,31 +14,6 @@ RSpec.describe 'projects/show', type: :view do
   it 'renders attributes in <p>' do
     render
     expect(rendered).to match(/Factory Project/)
-  end
-
-  context 'as hiwi' do
-    it 'shows leave project button if part of project' do
-      @project.users << @user
-      render
-      expect(rendered).to have_content(t('projects.show.leave_project'))
-    end
-
-    it 'shows no leave project button if not part of project' do
-      render
-      expect(rendered).to_not have_content(t('projects.show.leave_project'))
-    end
-
-    it 'shows add working hours button' do
-      @project.users << @user
-      render
-      expect(rendered).to have_content(t('projects.show.add_working_hours'))
-    end
-
-    it 'shows working hours' do
-      @project.users << @user
-      render
-      expect(rendered).to have_content(t('projects.show.working_hours'))
-    end
   end
 
   it 'has information about the project on page as a chair representative' do
@@ -72,20 +47,49 @@ RSpec.describe 'projects/show', type: :view do
     expect(page).to have_content(wimi.name)
   end
 
-  it 'has information about the project on page as a hiwi' do
-    chair_representative = FactoryGirl.create(:chair_representative, user: @user, chair: @chair).user
-    hiwi = FactoryGirl.create(:user)
+  context 'as hiwi' do
+    before(:each) do
+      chair_representative = FactoryGirl.create(:chair_representative, user: @user, chair: @chair).user
+      @hiwi = FactoryGirl.create(:user)
 
-    login_as hiwi
-    project = FactoryGirl.create(:project, chair: chair_representative.chair, status: true)
-    hiwi.projects << project
-    visit project_path(project.id)
+      login_as @hiwi
+      @project = FactoryGirl.create(:project, chair: chair_representative.chair, status: true)
+      visit project_path(@project.id)
+    end
 
-    expect(page).to have_content(project.title)
-    expect(page).to have_content(project.chair.name)
-    expect(page).to have_content(project.chair.representative.user.name)
-    expect(page).to have_content(I18n.t('projects.show.public'))
-    expect(page).to have_content(hiwi.name)
+    it 'has information about the project on page' do
+      expect(page).to have_content(@project.title)
+      expect(page).to have_content(@project.chair.name)
+      expect(page).to have_content(@project.chair.representative.user.name)
+      expect(page).to have_content(I18n.t('projects.show.public'))
+      expect(page).to have_content(@hiwi.name)
+    end
+
+    it 'shows leave project button if part of project' do
+      @hiwi.projects << @project
+      visit current_path
+      expect(page).to have_content('Leave Project')
+    end
+
+    it 'shows no leave project button if not part of project' do
+      expect(page).to_not have_content('Leave Project')
+    end
+
+    it 'shows add working hours button' do
+      @hiwi.projects << @project
+      visit current_path
+      expect(page).to have_link('Add working hours')
+    end
+
+    it 'shows no add working hours button if not part of project' do
+      expect(page).to_not have_link('Add working hours')
+    end
+
+    it 'shows working hours' do
+      @hiwi.projects << @project
+      visit current_path
+      expect(page).to have_content('Working hours')
+    end
   end
 
   it 'shows a button for a wimi to inspect a user specific working hour report for this project' do


### PR DESCRIPTION
#286:

Wenn ich als Hiwi /projects besuche und auf ein Projekt klicke, in dem ich kein Mitglied bin, kann ich auf der Detailseite Arbeitsstunden hinzufügen.
Das führt auf die Seite /work_days/new. Als Projekt kann man das andere allerdings nicht auswählen.