### PR TITLE
Feature/298 superadmin show profiles

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,12 @@
 class UsersController < ApplicationController
   before_filter :authenticate_user!, except: :superadmin_index
   before_action :user_exists, :set_user, except: [:superadmin_index, :language]
+  load_and_authorize_resource
+
+  rescue_from CanCan::AccessDenied do |_exception|
+    flash[:error] = I18n.t('not_authorized')
+    redirect_to dashboard_path
+  end
 
   def show
     @trips = @user.get_desc_sorted_trips

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,6 +14,8 @@ class Ability
         end
       end
     end
+
+    can :superadmin_index, User
   end
 
   def initialize_user(user)
@@ -24,6 +26,26 @@ class Ability
       project.public
     end
     can :create, ProjectApplication
+    can :show, User
+    can :read, User
+    can :update, User do |_user|
+      _user == user
+    end
+    can :edit, User do |_user|
+      _user == user
+    end
+    can :upload_signature, User do |_user|
+      _user == user
+    end
+    can :delete_signature, User do |_user|
+      _user == user
+    end
+    can :user_exists, User
+    can :resource_name, User
+    can :resource, User
+    can :devise_mapping, User
+    can :language, User
+    can :set_user, User
 
     can :accept_invitation, Project do |project|
       Invitation.select{ |i| i.user == user && i.project == project}
@@ -168,6 +190,9 @@ class Ability
     can     :manage,   Chair
     cannot  :see,      Chair
     cannot  :show,     Chair
+    can     :show,     User do |user|
+      user == _user
+    end
 
     cannot  :create,   ProjectApplication
     #assign representative/admin role to user

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -193,6 +193,24 @@ class Ability
     can     :show,     User do |user|
       user == _user
     end
+    can :update, User do |user|
+      _user == user
+    end
+    can :edit, User do |user|
+      _user == user
+    end
+    can :upload_signature, User do |user|
+      _user == user
+    end
+    can :delete_signature, User do |user|
+      _user == user
+    end
+    can :user_exists, User
+    can :resource_name, User
+    can :resource, User
+    can :devise_mapping, User
+    can :language, User
+    can :set_user, User
 
     cannot  :create,   ProjectApplication
     #assign representative/admin role to user

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -35,4 +35,20 @@ RSpec.describe 'users/show', type: :view do
     visit user_path(@user)
     expect(page).to have_content(chair.name)
   end
+
+  it 'allows the superadmin to see his own profile' do
+    superadmin = FactoryGirl.create(:user, superadmin: true)
+    login_as(superadmin, scope: :user)
+    visit user_path(superadmin)
+    expect(current_path).to eq(user_path(superadmin))
+  end
+
+  it 'does not allow the superadmin to see the profiles of other users' do
+    superadmin = FactoryGirl.create(:user, superadmin: true)
+    login_as(superadmin, scope: :user)
+
+    visit user_path(@user)
+    expect(current_path).to eq(dashboard_path)
+  end
+
 end


### PR DESCRIPTION
**Aktuell**
- Der Superadministrator kann Profile von Nutzern einsehen

**Erwartetes Verhalten**
- Der Superadmin soll nicht die Profile von anderne Nutzern einsehen können