### PR TITLE
feature/202_view_chair

### DIFF
--- a/app/views/chairs/show.html.erb
+++ b/app/views/chairs/show.html.erb
@@ -27,51 +27,50 @@
   </table>
 <% end %>
 
-<strong><%= I18n.t('roles.wimi_long_plural') %>:</strong>
-<br>
-<table class="table table-striped">
-  <% @chair.wimis.each do |wimi| %>
-    <tr>
-      <td><%= wimi.name %></td>
-      <td>
-        <% if current_user.is_representative?(@chair) %>
-          <%= I18n.t('chair.wimi.show_requests', default: 'Show Requests') %>
-        <% end %>
-      </td>
-      <td>
-        <% if wimi.is_admin?(@chair) %>
-          <%= I18n.t('roles.admin_long') %>
-          <% if current_user.is_admin?(@chair) && current_user != wimi %>
-            <%= link_to I18n.t('chairs.applications.withdraw_rights'), chairs_withdraw_admin_path(id: @chair, request: wimi.chair_wimi), method: :post, class: 'btn btn-danger btn-xs' %>
+<% unless @chair.wimis.blank? %>
+  <strong><%= I18n.t('roles.wimi_long_plural') %>:</strong>
+  <br>
+  <table class="table table-striped">
+    <% @chair.wimis.each do |wimi| %>
+      <tr>
+        <td><%= wimi.name %></td>
+        <td>
+          <% if wimi.is_admin?(@chair) %>
+            <%= I18n.t('roles.admin_long') %>
+            <% if current_user.is_admin?(@chair) && current_user != wimi %>
+              <%= link_to I18n.t('chairs.applications.withdraw_rights'), chairs_withdraw_admin_path(id: @chair, request: wimi.chair_wimi), method: :post, class: 'btn btn-danger btn-xs' %>
+            <% end %>
+          <% elsif wimi.is_representative?(@chair) %>
+            <%= I18n.t('roles.chair_representative') %>
+          <% else %>
+            <% if current_user.is_admin?(@chair) %>
+              <%= link_to I18n.t('chairs.applications.grant_rights'), chairs_set_admin_path(id: @chair, request: wimi.chair_wimi), method: :post, class: 'btn btn-success btn-xs' %>
+            <% end %>
           <% end %>
-        <% elsif wimi.is_representative?(@chair) %>
-          <%= I18n.t('roles.chair_representative') %>
-        <% else %>
-          <% if current_user.is_admin?(@chair) %>
-            <%= link_to I18n.t('chairs.applications.grant_rights'), chairs_set_admin_path(id: @chair, request: wimi.chair_wimi), method: :post, class: 'btn btn-success btn-xs' %>
+        </td>
+        <td>
+          <% if wimi.id != current_user.id && current_user.is_admin?(@chair) && !wimi.is_representative?(@chair) %>
+            <%= link_to I18n.t('chairs.applications.remove_from_chair'), chairs_remove_user_path(id: @chair, request: wimi.chair_wimi), method: :post, data: {confirm: t('helpers.links.confirm')}, class: 'btn btn-danger btn-xs' %>
           <% end %>
-        <% end %>
-      </td>
-      <td>
-        <% if wimi.id != current_user.id && current_user.is_admin?(@chair) && !wimi.is_representative?(@chair) %>
-          <%= link_to I18n.t('chairs.applications.remove_from_chair'), chairs_remove_user_path(id: @chair, request: wimi.chair_wimi), method: :post, data: {confirm: t('helpers.links.confirm')}, class: 'btn btn-danger btn-xs' %>
-        <% end %>
-      </td>
-    </tr>
-  <% end %>
-</table>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>
 
-<strong><%= I18n.t('roles.hiwi_long_plural') %>:</strong>
-<br>
-<table class="table table-striped">
-  <% @chair.hiwis.each do |hiwi| %>
-    <tr>
-      <td><%= hiwi.name %></td>
-      <td>
-        <% if current_user.chair_wimi.representative %>
-          <%= I18n.t('chairs.navigation.show_timesheets') %>
-        <% end %>
-      </td>
-    </tr>
-  <% end %>
-</table>
+<% unless @chair.hiwis.blank? %>
+  <strong><%= I18n.t('roles.hiwi_long_plural') %>:</strong>
+  <br>
+  <table class="table table-striped">
+    <% @chair.hiwis.each do |hiwi| %>
+      <tr>
+        <td><%= hiwi.name %></td>
+        <td>
+          <% if current_user.chair_wimi.representative %>
+            <%= I18n.t('chairs.navigation.show_timesheets') %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>


### PR DESCRIPTION
Zu #202:
- Auf der Übersichtsseite eines Fachgebiets sollen nur Überschriften zu Inhalten angezeigt werden, die auch vorhanden sind. Wenn es z.B. bisher keine Hiwis gibt, soll es daher keine Überschrift für Hiwis geben. 

- In der Übersicht der Wimis, die Mitglied des Fachgebiets sind, werden hinter jedem Namen "Show Requests" angezeigt. Dies sollte dort nicht auftauchen. 

![bildschirmfoto 2016-01-18 um 09 17 20](https://cloud.githubusercontent.com/assets/7271491/12386247/5d3b6322-bdc4-11e5-817c-0d710576e9d7.png)