### PR TITLE
Fix/258 wimi time sheet creation

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -91,6 +91,7 @@ class Ability
     can :sign_user_out, Project do |project|
       project.users.include? user
     end
+    cannot :add_working_hours, Project
     can :manage, ProjectApplication do |project_application|
       user.projects.exists?(project_application.project_id)
     end

--- a/spec/views/projects/show.html.erb_spec.rb
+++ b/spec/views/projects/show.html.erb_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'projects/show', type: :view do
     expect(page).to have_content(project.title)
     expect(page).to have_content(project.chair.name)
     expect(page).to have_content(project.chair.representative.user.name)
-    expect(page).to have_content(I18n.t('projects.show.public'))
+    expect(page).to have_content('public')
     expect(page).to have_content(representative.name)
   end
 
@@ -44,7 +44,7 @@ RSpec.describe 'projects/show', type: :view do
       expect(page).to have_content(@project.title)
       expect(page).to have_content(@project.chair.name)
       expect(page).to have_content(@project.chair.representative.user.name)
-      expect(page).to have_content(I18n.t('projects.show.public'))
+      expect(page).to have_content('public')
       expect(page).to have_content(@hiwi.name)
     end
 
@@ -90,7 +90,7 @@ RSpec.describe 'projects/show', type: :view do
       expect(page).to have_content(@project.title)
       expect(page).to have_content(@project.chair.name)
       expect(page).to have_content(@project.chair.representative.user.name)
-      expect(page).to have_content(I18n.t('projects.show.public'))
+      expect(page).to have_content('public')
       expect(page).to have_content(@wimi.name)
     end
 
@@ -115,7 +115,7 @@ RSpec.describe 'projects/show', type: :view do
       @wimi.projects << @project
       user.projects << @project
       visit current_path
-      expect(page).to have_selector(:link_or_button, I18n.t('projects.form.show_working_hours'))
+      expect(page).to have_selector(:link_or_button, 'Show working hours')
     end
 
     it 'shows one button to inspect all working hour report for this project' do
@@ -124,7 +124,7 @@ RSpec.describe 'projects/show', type: :view do
       user.projects << @project
       visit current_path
       expect(page).to have_content(I18n.t('projects.form.show_all_working_hours'), count: 1)
-      expect(page).to have_selector(:link_or_button, I18n.t('projects.form.show_all_working_hours'))
+      expect(page).to have_selector(:link_or_button, 'Show all working hours')
     end
   end
 end


### PR DESCRIPTION
Zu #258:

Nur als Hiwi ist es mir möglich, Stundenzettel / Arbeitsstunden hinzuzufügen. 

**Akzeptanzkriterien**
- [ ] Nehme ich eine andere Rolle ein, z.B. als Wimi, so ist in meinem Profil keine Sektion zu Arbeitsstunden sichtbar.

Anmerkung: Ich habe lediglich den eigentlichen Inhalt des Issues gefixt, nichts, was mit der Profilseite zusammenhängt. 