### PR TITLE
Feature/302 email validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,7 @@ class User < ActiveRecord::Base
 
   validates :first_name, length: {minimum: 1}
   validates :last_name, length: {minimum: 1}
-  validates :email, length: {minimum: 1}
+  validates :email, length: {minimum: 1}, user_email: true
   validates :personnel_number, numericality: {only_integer: true}, inclusion: 0..999999999
   validates_numericality_of :remaining_leave, greater_than_or_equal_to: 0
   validates_numericality_of :remaining_leave_last_year, greater_than_or_equal_to: 0

--- a/app/models/user_email_validator.rb
+++ b/app/models/user_email_validator.rb
@@ -1,0 +1,7 @@
+class UserEmailValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i or value == User::INVALID_EMAIL
+      record.errors[attribute] << (options[:message] || I18n.t("users.no_email"))
+    end
+  end
+end

--- a/config/locales/de.bootstrap.yml
+++ b/config/locales/de.bootstrap.yml
@@ -101,6 +101,7 @@ de:
       projects: "Projekte"
       all_working_hours: "Hiwi Stunden Gesamt für"
   users:
+    no_email: "ist keine gültige Email-Adresse."
     does_not_exist: "Dieser Benutzer existiert nicht."
     update:
       user_updated: "Profil erfolgreich aktualisiert"

--- a/config/locales/en.bootstrap.yml
+++ b/config/locales/en.bootstrap.yml
@@ -111,6 +111,7 @@ en:
       all_working_hours: "Overall Student Working Hours for"
   users:
     does_not_exist: "This user does not exist."
+    no_email: "is not a valid email address."
     update:
       user_updated: "Profile was successfully updated"
     show:

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -21,7 +21,7 @@ describe 'login via OpenID' do
       expect(page).to have_content 'Please set a valid email address first'
     end
 
-    fill_in 'user_email', with: 'valid email'
+    fill_in 'user_email', with: 'valid@e.mail'
     click_on 'Save'
 
     @routes.each do |route|

--- a/spec/features/profile/update_email_spec.rb
+++ b/spec/features/profile/update_email_spec.rb
@@ -15,9 +15,14 @@ describe 'updating email address' do
   end
 
   it 'should not update without a valid email address' do
-    invalid_email = 'invalid mail'
     former_mail = @user.email
-    fill_in :user_email, with: invalid_email
+    fill_in :user_email, with: 'invalid mail'
+    click_button 'Save'
+    expect(page).to have_text('is not a valid email address.')
+    fill_in :user_email, with: 'invalid.mail'
+    click_button 'Save'
+    expect(page).to have_text('is not a valid email address.')
+    fill_in :user_email, with: 'invalid@mail'
     click_button 'Save'
     expect(page).to have_text('is not a valid email address.')
     expect(@user.reload.email).to eq(former_mail)

--- a/spec/features/profile/update_email_spec.rb
+++ b/spec/features/profile/update_email_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'updating email address' do
+  before :each do
+    @user = FactoryGirl.create(:user)
+    login_as @user
+    visit edit_user_path(@user.id)
+  end
+
+  it 'should update with a valid email address' do
+    valid_email = 'valid@e.mail'
+    fill_in :user_email, with: valid_email
+    click_button 'Save'
+    expect(@user.reload.email).to eq(valid_email)
+  end
+
+  it 'should not update without a valid email address' do
+    invalid_email = 'invalid mail'
+    former_mail = @user.email
+    fill_in :user_email, with: invalid_email
+    click_button 'Save'
+    expect(page).to have_text('is not a valid email address.')
+    expect(@user.reload.email).to eq(former_mail)
+  end
+end


### PR DESCRIPTION
Für #302:

Im Moment wird nur das geprüft: `validates :email, length: {minimum: 1}`

Das könnte man erweitern, z.B. wie im zweiten Beispiel:
http://guides.rubyonrails.org/active_record_validations.html#custom-validators