### PR TITLE
destroying a chair also destroys its projects

### DIFF
--- a/app/models/chair.rb
+++ b/app/models/chair.rb
@@ -15,7 +15,7 @@ class Chair < ActiveRecord::Base
 
   has_many :chair_wimis, dependent: :destroy
   has_many :users, through: :chair_wimis
-  has_many :projects
+  has_many :projects, dependent: :destroy
   has_many :requests
   has_many :events
 

--- a/spec/controllers/chairs_controller_spec.rb
+++ b/spec/controllers/chairs_controller_spec.rb
@@ -351,6 +351,12 @@ RSpec.describe ChairsController, type: :controller do
         delete :destroy, {id: @chair.id}
       }.to change(Chair, :count).by(-1)
     end
+
+    it 'destroys the projects of the chair' do
+      project = FactoryGirl.create(:project, chair_id: @chair.id)
+      delete :destroy, {id: @chair.id}
+      expect project == nil
+    end
   end
 
   describe 'GET #requests' do


### PR DESCRIPTION
Issue #315 

Beispiel: Chair wird gelöscht, aber alle Projekte zum Chair existieren noch, dann geht man auf die Projects Index Seite und bekommt error weil project.chair nil ist.