### PR TITLE
Fix/315 loeschkaskaden

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -50,6 +50,7 @@ class ProjectsController < ApplicationController
   end
 
   def destroy
+    @project.destroy_invitations
     @project.destroy
     flash[:success] = 'Project was successfully destroyed.'
     redirect_to projects_url

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -47,6 +47,14 @@ class Project < ActiveRecord::Base
     end
   end
 
+  def destroy_invitations
+    invitation = Invitation.where(project: self)
+    invitation.each do |inv|
+      Event.find_by(trigger: inv.id).destroy!
+      inv.destroy!
+    end
+  end
+
   def destroy_invitation(user)
     inv = Invitation.find_by(user: user, project: self)
     Event.find_by(trigger: inv.id, target_id: user.id).destroy!

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -10,4 +10,3 @@
   <% end %>
 </div>
 <%= render partial: 'form' %>
-

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -191,6 +191,24 @@ RSpec.describe ProjectsController, type: :controller do
 
       expect(response).to redirect_to(projects_url)
     end
+
+    it 'destroys every associated Invitation and EventProjectInvitation' do
+      user2 = FactoryGirl.create(:user)
+      project = Project.create! valid_attributes
+      @user.projects << project
+
+      expect(Invitation.all.size).to eq(0)
+      expect(Event.all.size).to eq(0)
+
+      put :invite_user, {id: project.to_param, invite_user: {email: user2.email}}, valid_session
+
+      expect(Invitation.all.size).to eq(1)
+      expect(Event.all.size).to eq(1)
+
+      delete :destroy, {id: project.to_param}, valid_session
+      expect(Invitation.all.size).to eq(0)
+      expect(Event.all.size).to eq(0)
+    end
   end
 
   describe 'POST #invite_user' do


### PR DESCRIPTION
Invitations und EventProjectInvitations werden gelöscht, wenn das zugehörige Projekt gelöscht wird.