### PR TITLE
create a work day in order to test  the loop

### DIFF
--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe DocumentsController, type: :controller do
       chair = FactoryGirl.create(:chair)
       project = FactoryGirl.create(:project, chair: chair)
       time_sheet = FactoryGirl.create(:time_sheet, user_id: @user.id, project_id: project)
+      FactoryGirl.create(:work_day, user_id: @user.id, project_id: project.id)
       params = {doc_type: 'Timesheet', doc_id: time_sheet.id}
       get :generate_pdf, params
       expect(response.headers['Content-Type']).to eq('application/pdf')


### PR DESCRIPTION
Zu #309:

Es gab eine Loop im Controller von Documents, die durch die Tests nie berührt wurde. Das Erstellen eines Work Days am selben Tag behebt das (und erhöht die Coverage um ca. 0.2%).

