### PR TITLE
private projects can now only be seen by authorized users

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -63,7 +63,10 @@ class Ability
   def initialize_hiwi(user)
     initialize_user user
 
-    can :read, Project
+    can :read, Project do |project|
+      (project.public) ||
+      (project.users.include? user)
+    end
     cannot :create, ProjectApplication do |project_application|
       user.projects.exists?(project_application.project_id)
     end
@@ -82,7 +85,6 @@ class Ability
 
     alias_action :create, :read, :update, :destroy, to: :crud
 
-    can :read, Project
     can :create, Project
     can :manage, Project do |project|
       project.users.include?(user)
@@ -129,6 +131,9 @@ class Ability
   def initialize_representative(user)
     initialize_wimi user
 
+    can :read, Project do |project|
+      user.chair == project.chair
+    end
     can :see_holidays, User do |chair_user|
       chair_user.chair == user.chair
     end

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -127,7 +127,7 @@
       <div class="col-md-12 novertpadding col-sm-12">
         <div class="row">
           <div class="col-md-12 col-sm-12" style="padding-bottom: 0px;">
-            <strong> Invite Initial Users </strong> <br>
+            <strong> <%=t '.invite_init_user' %></strong> <br>
           </div>
         </div>
         <span class="row" style="padding-top: 0px;">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -30,50 +30,52 @@
             </thead>
             <tbody>
               <% @projects.each do |project| %>
-                <tr>
-                  <td><%= link_to project.title, project %></td>
-                  <td><%= link_to project.chair.name, project.chair %></td>
-                  <td><%= project.public ? t('.public', default:'public') : t('.private', default:'private') %></td>
+                <% if can? :read, project %>
+                  <tr>
+                    <td><%= link_to project.title, project %></td>
+                    <td><%= link_to project.chair.name, project.chair %></td>
+                    <td><%= project.public ? t('.public', default:'public') : t('.private', default:'private') %></td>
 
-                  <td><%= t('.status_' + project.status.to_s) %></td>
-                  <td><%=l project.created_at %></td>
-                  <td>
-                    <% if can? :create, ProjectApplication %>
-                      <% if project.project_applications.exists?(user: current_user) %>
-                        <% project_application = project.project_applications.find_by(user: current_user) %>
-                        <% case project_application.status %>
-                          <% when 'pending' %>
-                            <%= link_to t('project_applications.index.cancel', default: t('helpers.links.cancel')),
-                              project_application_path(project_application),
-                                        method: :delete,
-                                        data: { confirm: t('helpers.links.confirm') },
-                                        class: 'btn btn-danger btn-xs' %>
-                          <% when 'accepted' %>
-                            <span class='label label-success'><%= project_application.status %></span>
-                          <% when 'declined' %>
-                            <%= link_to t('project_applications.reapply', default: 'Reapply'),
-                              reapply_project_application_path(project_application), class: 'btn btn-danger btn-xs' %>
+                    <td><%= t('.status_' + project.status.to_s) %></td>
+                    <td><%=l project.created_at %></td>
+                    <td>
+                      <% if can? :create, ProjectApplication %>
+                        <% if project.project_applications.exists?(user: current_user) %>
+                          <% project_application = project.project_applications.find_by(user: current_user) %>
+                          <% case project_application.status %>
+                            <% when 'pending' %>
+                              <%= link_to t('project_applications.index.cancel', default: t('helpers.links.cancel')),
+                                project_application_path(project_application),
+                                          method: :delete,
+                                          data: { confirm: t('helpers.links.confirm') },
+                                          class: 'btn btn-danger btn-xs' %>
+                            <% when 'accepted' %>
+                              <span class='label label-success'><%= project_application.status %></span>
+                            <% when 'declined' %>
+                              <%= link_to t('project_applications.reapply', default: 'Reapply'),
+                                reapply_project_application_path(project_application), class: 'btn btn-danger btn-xs' %>
+                          <% end %>
+                        <% else %>
+                          <%= link_to t('helpers.links.apply'),
+                            apply_project_applications_path(id: project.id), method: :post, class: 'btn btn-default btn-xs' %>
                         <% end %>
-                      <% else %>
-                        <%= link_to t('helpers.links.apply'),
-                          apply_project_applications_path(id: project.id), method: :post, class: 'btn btn-default btn-xs' %>
                       <% end %>
-                    <% end %>
-                    <% if can? :leave_project, project %>
-                        <%= link_to t('projects.show.leave_project'),
-                                    sign_user_out_project_path(user_id: current_user.id, id: project), method: :delete, class: 'btn btn-default btn-xs' %>
-                    <% end %>
-                    <% if can? :manage, project%>
-                      <%= link_to t('helpers.links.edit'),
-                                  edit_project_path(project), class: 'btn btn-warning btn-xs' %>
-                      <%= link_to 'X',
-                                  project_path(project),
-                                  method: :delete,
-                                  data: { confirm: t('helpers.links.confirm') },
-                                  class: 'btn btn-xs btn-danger' %>
-                    <% end %>
-                  </td>
-                </tr>
+                      <% if can? :leave_project, project %>
+                          <%= link_to t('projects.show.leave_project'),
+                                      sign_user_out_project_path(user_id: current_user.id, id: project), method: :delete, class: 'btn btn-default btn-xs' %>
+                      <% end %>
+                      <% if can? :manage, project%>
+                        <%= link_to t('helpers.links.edit'),
+                                    edit_project_path(project), class: 'btn btn-warning btn-xs' %>
+                        <%= link_to 'X',
+                                    project_path(project),
+                                    method: :delete,
+                                    data: { confirm: t('helpers.links.confirm') },
+                                    class: 'btn btn-xs btn-danger' %>
+                      <% end %>
+                    </td>
+                  </tr>
+                <% end %>
               <% end %>
             </tbody>
           </table>

--- a/spec/views/projects/edit.html.erb_spec.rb
+++ b/spec/views/projects/edit.html.erb_spec.rb
@@ -126,8 +126,7 @@ RSpec.describe 'projects/edit', type: :view do
     expect(page).not_to have_selector(:link_or_button, I18n.t('helpers.links.edit'))
     expect(page).not_to have_selector(:link_or_button, I18n.t('helpers.links.destroy'))
     expect(page).not_to have_selector(:link_or_button, I18n.t('projects.show.set_inactive'))
-    #expect(page).to have_selector(:link_or_button, I18n.t('helpers.links.back'))
-    expect(page).to have_content(I18n.t('helpers.links.back'))
+    expect(page).to have_selector(:link_or_button, I18n.t('helpers.links.back'))
   end
 
   it 'denies the superadmin to edit a project' do

--- a/spec/views/projects/edit.html.erb_spec.rb
+++ b/spec/views/projects/edit.html.erb_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'projects/edit', type: :view do
 
   it 'not possible for wimi to edit or delete a project he just signed out' do
     login_as @wimi
-    project = FactoryGirl.create(:project, chair: @wimi.chair, public: false)
+    project = FactoryGirl.create(:project, chair: @wimi.chair)
     @wimi.projects << project
     visit edit_project_path(project)
     find('a[id="SignOutMyself"]').click
@@ -126,7 +126,8 @@ RSpec.describe 'projects/edit', type: :view do
     expect(page).not_to have_selector(:link_or_button, I18n.t('helpers.links.edit'))
     expect(page).not_to have_selector(:link_or_button, I18n.t('helpers.links.destroy'))
     expect(page).not_to have_selector(:link_or_button, I18n.t('projects.show.set_inactive'))
-    expect(page).to have_selector(:link_or_button, I18n.t('helpers.links.back'))
+    #expect(page).to have_selector(:link_or_button, I18n.t('helpers.links.back'))
+    expect(page).to have_content(I18n.t('helpers.links.back'))
   end
 
   it 'denies the superadmin to edit a project' do

--- a/spec/views/projects/index.html.erb_spec.rb
+++ b/spec/views/projects/index.html.erb_spec.rb
@@ -14,9 +14,43 @@ RSpec.describe 'projects/index', type: :view do
     render
   end
 
+  it 'does not show private projects that I do not belong to' do
+    chair = FactoryGirl.create(:chair)
+    chair2 = FactoryGirl.create(:chair)
+    @user.update(chair: chair)
+    not_my_project = FactoryGirl.create(:project, title: 'I should not see this project', public: false, chair: chair2)
+
+    visit projects_path
+
+    expect(page).to_not have_content(not_my_project.title)
+  end
+
+  it 'shows private projects that I do not belong to if I am representative of the chair' do
+    chair = FactoryGirl.create(:chair)
+    @user.update(chair: chair)
+    FactoryGirl.create(:wimi, user: @user, representative: true)
+    not_my_project = FactoryGirl.create(:project, title: 'I should not see this project', public: false, chair: chair)
+
+    visit projects_path
+
+    expect(page).to have_content(not_my_project.title)
+  end
+
+  it 'shows private projects that I belong to' do
+    chair = FactoryGirl.create(:chair)
+    @user.update(chair: chair)
+    my_project = FactoryGirl.create(:project, title: 'I should see this project', public: false, chair: chair)
+    my_project.users << @user
+
+    visit projects_path
+
+    expect(page).to have_content(my_project.title)
+  end
+
   it 'shows all details about a project' do
     chair = FactoryGirl.create(:chair)
     project = FactoryGirl.create(:project, chair: chair)
+    project.users << @user
 
     project.update(status: true)
     project.update(public: true)


### PR DESCRIPTION
Issue #329 

"Die Unterscheidung zwischen öffentlichen und privaten Projekten funktioniert nicht. Als Wimi kann ich sämtliche Projekte einsehen, egal ob öffentlich oder privat, egal von welchem Lehrstuhl. Private Projekte sollten nur für Ersteller/Mitglieder sichtbar sein, und auf das Fachgebiet bezogen für den Fachgebietsbeauftragten."

Sollte jetzt das gewünschte Verhalten zeigen.