### PR TITLE
'Hand in' instead of 'File request' (Holidays & Trips)

### DIFF
--- a/app/views/holidays/index.html.erb
+++ b/app/views/holidays/index.html.erb
@@ -26,7 +26,7 @@
             <td>
               <%= link_to t('helpers.links.show_details'), holiday, class: 'btn btn-default btn-xs' %>
               <% if holiday.status == 'saved' %>
-                <%= link_to t('holidays.show.file'),
+                <%= link_to t('holidays.show.hand_in'),
                           file_holiday_path(holiday), class: 'btn btn-success btn-xs' %>
                 <%= link_to t('.edit', default: t('helpers.links.edit')),
                           edit_holiday_path(holiday), class: 'btn btn-default btn-xs' %>

--- a/app/views/holidays/show.html.erb
+++ b/app/views/holidays/show.html.erb
@@ -74,7 +74,7 @@
       <div class="col-md-12">
         <div class="btn-group btn-group-justified">
           <% if @holiday.user == current_user && ((@holiday.status == 'saved') || (@holiday.status == 'declined')) %>
-            <%= link_to t('.file'), file_holiday_path, class: 'btn btn-success' %>
+            <%= link_to t('.hand_in'), file_holiday_path, class: 'btn btn-success' %>
             <%= link_to t('.destroy', default: t("helpers.links.destroy")), holiday_path(@holiday), method: :delete, data: { confirm: t('.confirm', default: t("helpers.links.confirm")) }, class: 'btn btn-danger' %>
           <% end %>
           <%= link_to t('helpers.links.download_pdf'), generate_pdf_path(doc_type: 'Holiday_request', doc_id: @holiday), class: 'btn btn-info' %>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -115,8 +115,6 @@
             <% if @trip.user == current_user %>
                 <% if @trip.has_expense? && !(@trip.expense.status == 'applied')  %>
                   <%= link_to t('helpers.links.edit'), edit_trip_expense_path(@trip,@trip.expense) , class: "btn btn-warning btn-block"%>
-                <% else %>
-                  <%= link_to t('helpers.links.edit'), '#', class: 'btn btn-warning btn-block', disabled: 'disabled', rel: "tooltip", title: (t '.filed_request_cant_be_edited') %>
                 <% end %>
             <% end %>
           </div>
@@ -128,7 +126,7 @@
       <%= render @trip.expense %>
       <div class="btn-group btn-group-justified">
         <% unless @trip.expense.status == 'applied' %>
-          <%= link_to t('.hand_in', default: t("helpers.links.hand_in")), hand_in_expense_path(@trip.expense), method: :post, class: 'btn btn-success' %>
+          <%= link_to t('.hand_in'), hand_in_expense_path(@trip.expense), method: :post, class: 'btn btn-success' %>
         <% end %>
           <%= link_to t('helpers.links.destroy'), trip_expense_path(@trip,@trip.expense), method: :delete, data: { confirm: 'Are you sure?' },class: "btn btn-danger" %>
           <%= link_to t('helpers.links.download_pdf'), generate_pdf_path(doc_type: 'Expense_request', doc_id: @trip.expense) , class: "btn btn-info"%>

--- a/config/locales/de.bootstrap.yml
+++ b/config/locales/de.bootstrap.yml
@@ -173,7 +173,7 @@ de:
   holidays:
     show:
       days: "Tag(e)"
-      file: "Antrag einreichen"
+      hand_in: "Antrag einreichen"
       reject: "Antrag ablehnen"
       accept: "Antrag annehmen"
       filed_request_cant_be_edited: "Ein eingereichter Antrag kann nicht bearbeitet werden."
@@ -272,7 +272,7 @@ de:
       status: "Status"
       user_id: "Benutzer"
       created_at: "Erstellungsdatum"
-      file: "Antrag einreichen"
+      hand_in: "Antrag einreichen"
       reject: "Antrag ablehnen"
       accept: "Antrag annehmen"
       filed_request_cant_be_edited: "Ein eingereichter Antrag kann nicht bearbeitet werden."

--- a/config/locales/en.bootstrap.yml
+++ b/config/locales/en.bootstrap.yml
@@ -182,7 +182,7 @@ en:
   holidays:
     show:
       days: "Day(s)"
-      file: "File Request"
+      hand_in: "Hand in"
       reject: "Reject Request"
       accept: "Accept Request"
       filed_request_cant_be_edited: "A filed request can't be edited"
@@ -282,7 +282,7 @@ en:
       status: "Status"
       user_id: "User"
       created_at: "Created at"
-      file: "File Request"
+      hand_in: "Hand in"
       reject: "Reject Request"
       accept: "Accept Request"
       filed_request_cant_be_edited: "A filed request can't be edited"

--- a/spec/views/dashboard/index.html.erb_spec.rb
+++ b/spec/views/dashboard/index.html.erb_spec.rb
@@ -175,9 +175,9 @@ RSpec.describe 'dashboard/index.html.erb', type: :view do
     holiday = FactoryGirl.create(:holiday, user: @user, signature: true)
     login_as @user
     visit holiday_path(holiday)
-    expect(page).to have_link t('holidays.show.file')
+    expect(page).to have_link t('holidays.show.hand_in')
 
-    click_on t('holidays.show.file')
+    click_on t('holidays.show.hand_in')
     expect(page).to have_content t('users.show.status.applied')
 
     FactoryGirl.create(:wimi, chair: chair, user: @user, representative: true)

--- a/spec/views/holidays/show.html.erb_spec.rb
+++ b/spec/views/holidays/show.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'holidays/show', type: :view do
     chair = FactoryGirl.create(:chair)
     ChairWimi.first.update_attributes(user_id: @user.id)
     visit holiday_path(@holiday.id)
-    click_on I18n.t('holidays.show.file')
+    click_on t('holidays.show.hand_in')
     @holiday.reload
     expect(@holiday.status).to eq('applied')
   end


### PR DESCRIPTION
Remove 'hand in' button for handed in expense resports (or not current_user)