### PR TITLE
Fix redirects for login and logout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,13 @@ class ApplicationController < ActionController::Base
 
   before_filter :set_locale
 
+  # Override the path that is redirected to after user is signed out.
+  # This defaults to root_path.
+  # https://github.com/plataformatec/devise/blob/master/lib/devise/controllers/helpers.rb
+  def after_sign_out_path_for(resource_or_scope)
+    new_user_session_path
+  end
+
   def ensure_valid_email
     requested_path = request.env['PATH_INFO']
     if current_user.nil?

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,25 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
+
+# Custom Devise FailureApp that redirects to external login on invalid login attempts.
+# http://stackoverflow.com/questions/5832631/devise-redirect-after-login-fail
+class RedirectFailure < Devise::FailureApp
+  def redirect_url
+    external_login_path
+  end
+
+  def respond
+    if http_auth?
+      http_auth
+    else
+      # https://github.com/plataformatec/devise/blob/69bee06ceee6280b54304928bb6e55c5064abad8/config/locales/en.yml
+      # https://github.com/plataformatec/devise/wiki/I18n
+      flash[:error] = I18n.t(:invalid, :authentication_keys => 'username', :scope => [:devise, :failure])
+      redirect
+    end
+  end
+end
+
 Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
@@ -245,6 +265,13 @@ Devise.setup do |config|
   #   manager.intercept_401 = false
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
+
+  # Use custom Devise FailureApp that redirects to external login
+  # when an invalid username / password is given.
+  # Defined in lib/redirect_failure.rb
+  config.warden do |manager|
+    manager.failure_app = RedirectFailure
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -268,7 +268,6 @@ Devise.setup do |config|
 
   # Use custom Devise FailureApp that redirects to external login
   # when an invalid username / password is given.
-  # Defined in lib/redirect_failure.rb
   config.warden do |manager|
     manager.failure_app = RedirectFailure
   end


### PR DESCRIPTION
Invalid login attempts redirect to `/extern` with flash message.
After logout, users are redirected to `/users/sign_in` with flash message.
Before, users where redirected (by default) to `/` after logout, which automatically redirected them again to `/users/sign_in`, as `/` is not viewable when not logged in. This behavior discarded set flash messages.