### PR TITLE
Allow submitting signed time sheet to chair admin

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,3 +1,4 @@
+# lib/document_builder.rb
 require 'document_builder'
 
 class DocumentsController < ApplicationController
@@ -7,7 +8,7 @@ class DocumentsController < ApplicationController
     else
       builder = DocumentBuilder.new(params)
       pdf = builder.build_pdf
-      send_data(pdf, filename: builder.build_file_name << '.pdf',  type: 'application/pdf')
+      send_data(pdf, filename: builder.build_file_name, type: 'application/pdf')
     end
   end 
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,82 +1,13 @@
+require 'document_builder'
+
 class DocumentsController < ApplicationController
   def generate_pdf
     if !params[:doc_type] or !params[:doc_id]
       raise ArgumentError, 'doc_type or doc_id is not set'
     else
-      pdf = build_pdf(params)
-      send_data(pdf, filename: build_file_name << '.pdf',  type: 'application/pdf')
+      builder = DocumentBuilder.new(params)
+      pdf = builder.build_pdf
+      send_data(pdf, filename: builder.build_file_name << '.pdf',  type: 'application/pdf')
     end
   end 
-
-  def build_pdf(params)
-    init_params(params)
-    # WickedPDF looks for stylesheet files in app/assets/stylesheets
-    @tmp_vars[:css_file] = 'document.css'
-    @tmp_vars[:hpi_logo] = "#{Rails.root}/app/assets/images/HPI-Logo.jpg"
-
-    pdf = WickedPdf.new.pdf_from_string(render_to_string(
-                                          'documents/' << @doc_type << '.html.erb',
-      layout: false,
-      locals: @tmp_vars))
-
-    return pdf
-  end
-
-  private
-
-  def build_file_name
-    if @doc_type == 'Timesheet'
-      @tmp_vars[:timesheet].pdf_export_name
-    else
-      @doc_type
-    end
-  end
-
-  def init_params(params)
-    @doc_type = params[:doc_type]
-    @tmp_vars = {}
-    case @doc_type
-    when 'Trip_request'
-      @tmp_vars[:trip] = Trip.find(params[:doc_id])
-      @tmp_vars[:trip].annotation = @tmp_vars[:trip].annotation || ''
-      @tmp_vars[:annotation_splitted] = @tmp_vars[:trip].annotation.split("\n")[0, 4]
-    when 'Holiday_request'
-      @tmp_vars[:holiday] = Holiday.find(params[:doc_id])
-    when 'Expense_request'
-      @tmp_vars[:report] = Expense.find(params[:doc_id])
-      @tmp_vars[:reason_splitted] = @tmp_vars[:report].reason.split("\n")
-    when 'Timesheet'
-      @tmp_vars[:timesheet] = TimeSheet.find(params[:doc_id])
-      @tmp_vars[:days_in_month] = []
-      @tmp_vars[:work_days] = @tmp_vars[:timesheet].work_days
-      @tmp_vars[:include_comments] = params[:include_comments] == '1'
-      # First day of month
-      day = Date.new(@tmp_vars[:timesheet].year, @tmp_vars[:timesheet].month)
-      # Iterate over all days for this month
-      while day.month == @tmp_vars[:timesheet].month
-        @tmp_vars[:days_in_month].push({
-          date: day, start: ' ', break: ' ', end: ' ',
-          duration: '0:00', notes: ' '
-        })
-        day += 1 # Select following day
-      end
-      for workday in @tmp_vars[:timesheet].work_days do
-        for day in @tmp_vars[:days_in_month] do
-          if workday.date == day[:date]
-            day[:start] = workday.start_time.strftime('%H:%M')
-            break_minutes = workday.break % 60
-            break_hours = (workday.break - break_minutes) / 60
-            day[:break] = format("%d:%02d", break_hours, break_minutes)
-            day[:end] = workday.end_time.strftime('%H:%M')
-            day[:duration] = workday.duration_hours_minutes
-            day[:notes] = workday.notes
-            day[:status] = workday.status
-          end
-        end
-      end
-      @tmp_vars[:sum] = @tmp_vars[:timesheet].sum_minutes_formatted
-    else
-      raise NotImplementedError
-    end
-  end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -3,18 +3,26 @@ class DocumentsController < ApplicationController
     if !params[:doc_type] or !params[:doc_id]
       raise ArgumentError, 'doc_type or doc_id is not set'
     else
-      init_params
-      # WickedPDF looks for stylesheet files in app/assets/stylesheets
-      @tmp_vars[:css_file] = 'document.css'
-      @tmp_vars[:hpi_logo] = "#{Rails.root}/app/assets/images/HPI-Logo.jpg"
-
-      pdf = WickedPdf.new.pdf_from_string(render_to_string(
-                                            'documents/' << @doc_type << '.html.erb',
-        layout: false,
-        locals: @tmp_vars))
+      pdf = build_pdf(params)
       send_data(pdf, filename: build_file_name << '.pdf',  type: 'application/pdf')
     end
+  end 
+
+  def build_pdf(params)
+    init_params(params)
+    # WickedPDF looks for stylesheet files in app/assets/stylesheets
+    @tmp_vars[:css_file] = 'document.css'
+    @tmp_vars[:hpi_logo] = "#{Rails.root}/app/assets/images/HPI-Logo.jpg"
+
+    pdf = WickedPdf.new.pdf_from_string(render_to_string(
+                                          'documents/' << @doc_type << '.html.erb',
+      layout: false,
+      locals: @tmp_vars))
+
+    return pdf
   end
+
+  private
 
   def build_file_name
     if @doc_type == 'Timesheet'
@@ -24,7 +32,7 @@ class DocumentsController < ApplicationController
     end
   end
 
-  def init_params
+  def init_params(params)
     @doc_type = params[:doc_type]
     @tmp_vars = {}
     case @doc_type

--- a/app/controllers/time_sheets_controller.rb
+++ b/app/controllers/time_sheets_controller.rb
@@ -115,6 +115,13 @@ class TimeSheetsController < ApplicationController
     end
   end
 
+  def send_to_admin
+    set_time_sheet
+    @time_sheet.contract.chair.admin_users.each do |user|
+      @time_sheet.send_to(user,current_user)
+    end
+  end
+
   def download
     set_time_sheet
     authorize! :show, @time_sheet

--- a/app/controllers/time_sheets_controller.rb
+++ b/app/controllers/time_sheets_controller.rb
@@ -120,6 +120,7 @@ class TimeSheetsController < ApplicationController
     @time_sheet.contract.chair.admin_users.each do |user|
       @time_sheet.send_to(user,current_user)
     end
+    redirect_to time_sheet_path(@time_sheet)
   end
 
   def download

--- a/app/controllers/time_sheets_controller.rb
+++ b/app/controllers/time_sheets_controller.rb
@@ -118,7 +118,7 @@ class TimeSheetsController < ApplicationController
   def send_to_admin
     set_time_sheet
     @time_sheet.contract.chair.admin_users.each do |user|
-      @time_sheet.send_to(user,current_user)
+      Event.add(:time_sheet_admin_mail, current_user, @time_sheet, user)
     end
     redirect_to time_sheet_path(@time_sheet)
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,13 +3,26 @@ class ApplicationMailer < ActionMailer::Base
   include CanCan::ControllerAdditions
 
   def notification(event, user)
+    prepare_mail(event,user)
+    # default from is configured in environments.
+    mail(to: user.email, subject: @subject, content_type: 'text/html')
+  end
+
+  def notification_with_pdf(event, user, pdf, pdfname)
+    prepare_mail(event,user)
+    # default from is configured in environments.
+    attachments[pdfname] = pdf
+    mail(to: user.email, subject: @subject, template_name: "notification")
+  end
+
+  private
+
+  def prepare_mail(event,user)
     @event = event
     @user = user
     # locale needs to be set manually, as the ApplicationMailer
     # is not aware of the user's language settings
-    subject = t('.subject', locale: user.language,
+    @subject = t('application_mailer.notification.subject', locale: user.language,
       text: t("event.user_friendly_name.#{@event.type}", locale: user.language))
-    # default from is configured in environments.
-    mail(to: user.email, subject: subject, content_type: 'text/html')
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -43,6 +43,10 @@ class Ability
       ts.user == user and user.has_contract_for(ts.month, ts.year)
     end
     can :withdraw, TimeSheet, user: {id: user.id}, handed_in: true, status: 'pending'
+    can :send_to_admin, TimeSheet, user: {id: user.id}, status: 'accepted', signed: true, wimi_signed: true
+    cannot :send_to_admin, TimeSheet do |ts|
+      ts.has_been_sent_to_admin?
+    end
 
     can :current, TimeSheet if (TimeSheet.current(user).any? or can?(:create, TimeSheet))
  
@@ -72,6 +76,9 @@ class Ability
     can :ts_wimi_actions, TimeSheet, contract: { responsible_id: user.id }
     can :see_wimi_actions, TimeSheet, contract: { responsible_id: user.id }, handed_in: true
     can :send_to_admin, TimeSheet, contract: { responsible_id: user.id }, status: 'accepted', signed: true, wimi_signed: true
+    cannot :send_to_admin, TimeSheet do |ts|
+      ts.has_been_sent_to_admin?
+    end
 
     # allow access to time sheets and contracts of other wimis if time sheet is 'pending'
     can [:ts_wimi_actions, :see_wimi_actions], TimeSheet, status: 'pending', contract: { chair_id: user.chair.id }

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -44,9 +44,6 @@ class Ability
     end
     can :withdraw, TimeSheet, user: {id: user.id}, handed_in: true, status: 'pending'
     can :send_to_admin, TimeSheet, user: {id: user.id}, status: 'accepted', signed: true, wimi_signed: true
-    cannot :send_to_admin, TimeSheet do |ts|
-      ts.has_been_sent_to_admin?
-    end
 
     can :current, TimeSheet if (TimeSheet.current(user).any? or can?(:create, TimeSheet))
  
@@ -76,9 +73,6 @@ class Ability
     can :ts_wimi_actions, TimeSheet, contract: { responsible_id: user.id }
     can :see_wimi_actions, TimeSheet, contract: { responsible_id: user.id }, handed_in: true
     can :send_to_admin, TimeSheet, contract: { responsible_id: user.id }, status: 'accepted', signed: true, wimi_signed: true
-    cannot :send_to_admin, TimeSheet do |ts|
-      ts.has_been_sent_to_admin?
-    end
 
     # allow access to time sheets and contracts of other wimis if time sheet is 'pending'
     can [:ts_wimi_actions, :see_wimi_actions], TimeSheet, status: 'pending', contract: { chair_id: user.chair.id }
@@ -120,5 +114,8 @@ class Ability
     cannot :receive_email, Event, user: { id: user.id }
     cannot [:hand_in, :destroy, :close], TimeSheet, status: 'closed'
     cannot [:close], TimeSheet, status: 'accepted'
+    cannot :send_to_admin, TimeSheet do |ts|
+      ts.has_been_sent_to_admin?
+    end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -71,6 +71,7 @@ class Ability
     can [:read, :create, :update], Contract, responsible_id: user.id
     can :ts_wimi_actions, TimeSheet, contract: { responsible_id: user.id }
     can :see_wimi_actions, TimeSheet, contract: { responsible_id: user.id }, handed_in: true
+    can :send_to_admin, TimeSheet, contract: { responsible_id: user.id }, status: 'accepted', signed: true, wimi_signed: true
 
     # allow access to time sheets and contracts of other wimis if time sheet is 'pending'
     can [:ts_wimi_actions, :see_wimi_actions], TimeSheet, status: 'pending', contract: { chair_id: user.chair.id }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -30,11 +30,14 @@ class Event < ActiveRecord::Base
 
   # Events listed here will not send Emails after creation
   # and will also not appear in Users email settings
-  NOMAIL = [:time_sheet_admin_mail.to_s].freeze
+  NOMAIL = [].freeze
+
+  ATTACHMENT = [:time_sheet_admin_mail.to_s].freeze
 
   validates_presence_of :user, :target_user, :object
 
-  after_create :send_mail, unless: :has_mail_disabled?
+  after_create :send_mail, unless: Proc.new { self.has_mail_disabled? or self.has_attachment? }
+  after_create :send_mail_with_attachment, if: :has_attachment?
 
   def self.add(type, user, object, target_user)
     event = self.new({ type: type, user: user, object: object, target_user: target_user})
@@ -59,6 +62,14 @@ class Event < ActiveRecord::Base
     NOMAIL.include?(self.type)
   end
 
+  def has_attachment?
+    ATTACHMENT.include?(self.type) and self.object_can_make_attachment?
+  end
+
+  def object_can_make_attachment?
+    self.object != nil and self.object.respond_to?(:make_attachment) and self.object.respond_to?(:attachment_name)
+  end
+
   def self.mail_enabled_types
     self.types.select { |t,v| !NOMAIL.include?(t) }
   end
@@ -66,6 +77,13 @@ class Event < ActiveRecord::Base
   def send_mail
     users_want_mail.each do |user|
       ApplicationMailer.notification(self, user).deliver_now
+    end
+  end
+
+  def send_mail_with_attachment
+    attachment = object.make_attachment
+    users_want_mail.each do |user|
+      ApplicationMailer.notification_with_pdf(self, user, attachment, "#{object.attachment_name}.pdf").deliver_now
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,6 +12,9 @@
 #
 
 class Event < ActiveRecord::Base
+  scope :object, -> object { where("object_id=?", object.id) }
+  scope :type, -> sym { where("type=?", self.types[sym])}
+
   # need this to prevent rails from doing single inheritance
   # because we have a field 'type'
   self.inheritance_column = nil

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,7 +25,7 @@ class Event < ActiveRecord::Base
   enum type: [ :time_sheet_hand_in, :time_sheet_accept, :time_sheet_decline,
     :project_create, :project_join, :project_leave, :chair_join, :chair_leave,
     :chair_add_admin, :contract_create, :contract_extend,
-    :time_sheet_closed
+    :time_sheet_closed, :time_sheet_admin_mail
   ]
 
   validates_presence_of :user, :target_user, :object

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,7 +32,7 @@ class Event < ActiveRecord::Base
   # and will also not appear in Users email settings
   NOMAIL = [].freeze
 
-  ATTACHMENT = [:time_sheet_admin_mail.to_s].freeze
+  ATTACHMENT = [:time_sheet_admin_mail.to_s, :time_sheet_accept.to_s].freeze
 
   validates_presence_of :user, :target_user, :object
 

--- a/app/models/time_sheet.rb
+++ b/app/models/time_sheet.rb
@@ -1,3 +1,5 @@
+require 'document_builder'
+
 # == Schema Information
 #
 # Table name: time_sheets
@@ -96,8 +98,6 @@ class TimeSheet < ActiveRecord::Base
   def send_to(user, sender)
     event = Event.add(:time_sheet_admin_mail, sender, self, user)
     mail = ApplicationMailer.notification(event, user)
-    # uuh this sends mail twice
-    # how to integrate attachments into event model ?
 
     mail.attachments[self.user.name + ' ' + self.name + '.pdf'] = self.make_pdf
     mail.deliver_now
@@ -110,7 +110,8 @@ class TimeSheet < ActiveRecord::Base
     params[:doc_id] = self.id
     # TODO: how should we handle this? ask the responsible instead?
     params[:include_comments] = self.user.include_comments == 'always' ? 1 : 0
-    pdf = DocumentsController.build_pdf(params)
+    builder = DocumentBuilder.new(params)
+    pdf = builder.build_pdf()
     return pdf
   end
 

--- a/app/models/time_sheet.rb
+++ b/app/models/time_sheet.rb
@@ -93,6 +93,27 @@ class TimeSheet < ActiveRecord::Base
     return success
   end
 
+  def send_to(user, sender)
+    event = Event.add(:time_sheet_admin_mail, sender, self, user)
+    mail = ApplicationMailer.notification(event, user)
+    # uuh this sends mail twice
+    # how to integrate attachments into event model ?
+
+    mail.attachments[self.user.name + ' ' + self.name + '.pdf'] = self.make_pdf
+    mail.deliver_now
+    # TODO: write tests
+  end
+
+  def make_pdf
+    params = {}
+    params[:doc_type] = 'Timesheet'
+    params[:doc_id] = self.id
+    # TODO: how should we handle this? ask the responsible instead?
+    params[:include_comments] = self.user.include_comments == 'always' ? 1 : 0
+    pdf = DocumentsController.build_pdf(params)
+    return pdf
+  end
+
   def reject_work_day(attributes)
     exists = attributes['id'].present?
     empty = attributes.slice(:start_time, :end_time).values.all?(&:blank?)

--- a/app/models/time_sheet.rb
+++ b/app/models/time_sheet.rb
@@ -97,11 +97,9 @@ class TimeSheet < ActiveRecord::Base
 
   def send_to(user, sender)
     event = Event.add(:time_sheet_admin_mail, sender, self, user)
-    mail = ApplicationMailer.notification(event, user)
+    mail = ApplicationMailer.notification_with_pdf(event, user, self.make_pdf, "#{self.pdf_export_name}.pdf")
 
-    mail.attachments[self.user.name + ' ' + self.name + '.pdf'] = self.make_pdf
     mail.deliver_now
-    # TODO: write tests
   end
 
   def make_pdf

--- a/app/models/time_sheet.rb
+++ b/app/models/time_sheet.rb
@@ -95,14 +95,7 @@ class TimeSheet < ActiveRecord::Base
     return success
   end
 
-  def send_to(user, sender)
-    event = Event.add(:time_sheet_admin_mail, sender, self, user)
-    mail = ApplicationMailer.notification_with_pdf(event, user, self.make_pdf, "#{self.pdf_export_name}.pdf")
-
-    mail.deliver_now
-  end
-
-  def make_pdf
+  def make_attachment
     params = {}
     params[:doc_type] = 'Timesheet'
     params[:doc_id] = self.id
@@ -226,7 +219,7 @@ class TimeSheet < ActiveRecord::Base
   # Used by controllers/documents_controller.rb to
   # set the name of exported PDFs of time sheets.
   # Is always in German, as is the exported document
-  def pdf_export_name
+  def attachment_name
     last_name = self.user.last_name
     date = I18n.l(self.first_day, format: "%m %Y")
     return "Arbeitszeitnachweis #{last_name} #{date}"

--- a/app/models/time_sheet.rb
+++ b/app/models/time_sheet.rb
@@ -229,6 +229,10 @@ class TimeSheet < ActiveRecord::Base
     I18n.l(Date.new(year, month, 1), format: :short_month_year)
   end
 
+  def has_been_sent_to_admin?
+    Event.object(self).type(:time_sheet_admin_mail).any?
+  end
+
   private
 
   # Initialize the TimeSheet to status "created", if not other status is set.

--- a/app/views/application_mailer/notification.html.erb
+++ b/app/views/application_mailer/notification.html.erb
@@ -1,6 +1,6 @@
-<%= content_tag :p, t('.hello', name: @user.first_name) %>
+<%= content_tag :p, t('application_mailer.notification.hello', name: @user.first_name) %>
 
-<%= content_tag :p, t('.new_notification', date: l(@event.created_at, format: :full)) %>
+<%= content_tag :p, t('application_mailer.notification.new_notification', date: l(@event.created_at, format: :full)) %>
 
 <%= content_tag :p do %>
   <%= render partial: 'shared/event_message', locals: {event: @event, user: @user} %>
@@ -10,11 +10,11 @@
 <%= content_tag :p, extended if extended != '' %>
 
 <%= content_tag :p do %>
-  <%= t('.your_wimi_portal') %>
+  <%= t('application_mailer.notification.your_wimi_portal') %>
   <br>
   <%= link_to(root_url, root_url) %>
 <% end %>
 
 <hr>
 
-<%= content_tag :p, t('.settings_reminder_html', href: edit_user_url(@user)) %>
+<%= content_tag :p, t('application_mailer.notification.settings_reminder_html', href: edit_user_url(@user)) %>

--- a/app/views/time_sheets/_wimi_actions.html.erb
+++ b/app/views/time_sheets/_wimi_actions.html.erb
@@ -37,6 +37,8 @@
   <hr>
 <% end %> <%# if @time_sheet.status.include? 'pending' %>
 
+<%= can_link t('.send_to_admin'), :send_to_admin, @time_sheet,  class: 'btn btn-success btn-block', style: "margin-bottom: 5px;" %>
+
 <script type="text/javascript">
 (function( $btn ) {
   $btn.on('click', function(event) {

--- a/app/views/time_sheets/_wimi_actions.html.erb
+++ b/app/views/time_sheets/_wimi_actions.html.erb
@@ -37,8 +37,6 @@
   <hr>
 <% end %> <%# if @time_sheet.status.include? 'pending' %>
 
-<%= can_link t('.send_to_admin'), :send_to_admin, @time_sheet,  class: 'btn btn-success btn-block', style: "margin-bottom: 5px;" %>
-
 <script type="text/javascript">
 (function( $btn ) {
   $btn.on('click', function(event) {

--- a/app/views/time_sheets/show.html.erb
+++ b/app/views/time_sheets/show.html.erb
@@ -143,6 +143,8 @@
   <span class="btn-block" data-toggle="tooltip" data-placement="bottom" title="<%= t('dashboard.missing_timesheets.close_tooltip', month: @time_sheet.name) %>">
     <%= action_button :close, @time_sheet, method: :post, class: 'btn-block btn-danger', :data => { confirm: t('helpers.links.confirm_action.message', model: @time_sheet.name, action: t('helpers.links.confirm_action.archive')) } %>
   </span>
+  <%# Send to admin button %>
+  <%= can_link t('.send_to_admin'), :send_to_admin, @time_sheet,  class: 'btn btn-success btn-block', style: "margin-bottom: 5px;" %>
   <%# Month switch buttons %>
   <hr>
   <% if @next_month %>

--- a/app/views/users/_event_settings.html.erb
+++ b/app/views/users/_event_settings.html.erb
@@ -5,7 +5,7 @@
   <div class="panel panel-body">
     <table class="table table-condensed table-hover" style="width: 60%;">
       <tbody>
-        <% Event.types.each do |typename, val| %>
+        <% Event.mail_enabled_types.each do |typename, val| %>
           <tr>
             <td><%= t "event.user_friendly_name.#{typename}" %></td>
             <td>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -43,7 +43,7 @@
     <div class="panel-body">
       <table class="table table-condensed table-hover">
         <tbody>
-          <% Event.types.each do |typename, val| %>
+          <% Event.mail_enabled_types.each do |typename, val| %>
             <tr>
               <%# .show sets element to display:block using bootstrap stylesheet, making label take up the width of the <td> %>
               <td style="vertical-align: bottom;">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -330,6 +330,7 @@ de:
       time_sheet_accept: Stundenzettel angenommen
       time_sheet_decline: Stundenzettel abgelehnt
       time_sheet_closed: Stundenzettel archiviert
+      time_sheet_admin_mail: Stundenzettel Admin Mail
       project_create: Neues Projekt erstellt
       project_join: Neues Projektmitglied
       project_leave: Projektmitglied entfernt
@@ -549,6 +550,7 @@ de:
       accept: Annehmen
       reject: Ablehnen
       add_signature: Unterschrift hinzufügen
+      send_to_admin: PDF an Admin senden
     accept_reject:
       flash:
         rejected: Stundenzettel wurde erfolgreich abgelehnt

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -547,11 +547,11 @@ de:
       at: Am
       reject_reason: Ablehnungsgrund
       signatures: Unterschriften
+      send_to_admin: PDF an Admin senden
     wimi_actions:
       accept: Annehmen
       reject: Ablehnen
       add_signature: Unterschrift hinzufügen
-      send_to_admin: PDF an Admin senden
     accept_reject:
       flash:
         rejected: Stundenzettel wurde erfolgreich abgelehnt

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -317,6 +317,7 @@ de:
     time_sheet_accept: "%{user} hat den Stundenzettel %{obj} von %{target_user} akzeptiert"
     time_sheet_decline: "%{user} hat den Stundenzettel %{obj} von %{target_user} abgelehnt"
     time_sheet_closed: "%{user} hat den Stundenzettel %{obj} von %{target_user} archiviert, in Papierform abgegeben"
+    time_sheet_admin_mail: "%{user} hat den Stundenzettel %{obj} an %{target_user} gesendet"
     project_create: "%{user} hat das Projekt %{obj} erstellt"
     project_join: "%{user} hat %{target_user} zu %{obj} hinzugefügt"
     project_leave: "%{user} hat %{target_user} aus dem Projekt %{obj} entfernt"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -341,6 +341,7 @@ de:
       contract_create: Vertragserstellung
       contract_extend: Vertragsverlängerung
     extended_message:
+      time_sheet_accepted: 'Der Stundenzettel kann auch über das Portal an das Sekretariat gesendet werden. (Via "An Admin senden" auf der Studenzettel Seite)'
       time_sheet_closed: Bitte stelle sicher, dass die Arbeitsstunden korrekt eingetragen sind.
   expense:
     applied: Reisekostenabrechnung bereits eingereicht

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,6 +330,7 @@ en:
       time_sheet_accept: Time sheet accepted
       time_sheet_decline: Time sheet declined
       time_sheet_closed: Time sheet archived
+      time_sheet_admin_mail: Time sheet Admin Mail
       project_create: Project creation
       project_join: Someone joined project
       project_leave: Someone left project
@@ -549,6 +550,7 @@ en:
       accept: Accept
       reject: Reject
       add_signature: Add Signature
+      send_to_admin: Send PDF to Admin
     accept_reject:
       flash:
         rejected: Time sheet was successfully rejected

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -317,6 +317,7 @@ en:
     time_sheet_accept: "%{user} accepted the time sheet %{obj} of %{target_user}"
     time_sheet_decline: "%{user} rejected the time sheet %{obj} of %{target_user}"
     time_sheet_closed: "%{user} archived the time sheet %{obj} of %{target_user}, it was handed in manually"
+    time_sheet_admin_mail: "%{user} sent the time sheet %{obj} to %{target_user}"
     project_create: "%{user} created project %{obj}"
     project_join: "%{user} added %{target_user} to %{obj}"
     project_leave: "%{user} removed %{target_user} from project %{obj}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -547,11 +547,11 @@ en:
       at: At
       reject_reason: Rejection reason
       signatures: Signatures
+      send_to_admin: Send PDF to Admin
     wimi_actions:
       accept: Accept
       reject: Reject
       add_signature: Add Signature
-      send_to_admin: Send PDF to Admin
     accept_reject:
       flash:
         rejected: Time sheet was successfully rejected

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -341,6 +341,7 @@ en:
       contract_create: Contract creation
       contract_extend: Contract extension
     extended_message:
+      time_sheet_admin_mail: 'The time sheet can be send to the Admin via the portal. (Via "Send to admin" button on the time sheet page)'
       time_sheet_closed: Please make sure that the working hours were entered correctly.
   expense:
     applied: Expense is already applied

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -341,7 +341,7 @@ en:
       contract_create: Contract creation
       contract_extend: Contract extension
     extended_message:
-      time_sheet_admin_mail: 'The time sheet can be send to the Admin via the portal. (Via "Send to admin" button on the time sheet page)'
+      time_sheet_accepted: 'The time sheet can be send to the Admin via the portal. (Via "Send to admin" button on the time sheet page)'
       time_sheet_closed: Please make sure that the working hours were entered correctly.
   expense:
     applied: Expense is already applied

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
       get 'download'
       post 'close'
       get 'reopen'
+      get 'send_to_admin'
     end
     collection do
       get 'current'

--- a/lib/document_builder.rb
+++ b/lib/document_builder.rb
@@ -8,21 +8,25 @@ class DocumentBuilder < ActionController::Base
     # WickedPDF looks for stylesheet files in app/assets/stylesheets
     @tmp_vars[:css_file] = 'document.css'
     @tmp_vars[:hpi_logo] = "#{Rails.root}/app/assets/images/HPI-Logo.jpg"
-    
-    pdf = WickedPdf.new.pdf_from_string(render_to_string(
-    'documents/' << @doc_type << '.html.erb',
-    layout: false,
-    locals: @tmp_vars))
-    
+
+    pdf = WickedPdf.new.pdf_from_string(
+      render_to_string(
+        "documents/#{@doc_type}.html.erb",
+        layout: false,
+        locals: @tmp_vars
+      )
+    )
+
     return pdf
   end
   
   def build_file_name
     if @doc_type == 'Timesheet'
-      @tmp_vars[:timesheet].pdf_export_name
+      file_name = @tmp_vars[:timesheet].pdf_export_name
     else
-      @doc_type
+      file_name = @doc_type
     end
+    file_name + '.pdf'
   end
 
   private

--- a/lib/document_builder.rb
+++ b/lib/document_builder.rb
@@ -1,0 +1,77 @@
+class DocumentBuilder < ActionController::Base
+
+  def initialize(params)
+    init_params(params)
+  end
+  
+  def build_pdf
+    # WickedPDF looks for stylesheet files in app/assets/stylesheets
+    @tmp_vars[:css_file] = 'document.css'
+    @tmp_vars[:hpi_logo] = "#{Rails.root}/app/assets/images/HPI-Logo.jpg"
+    
+    pdf = WickedPdf.new.pdf_from_string(render_to_string(
+    'documents/' << @doc_type << '.html.erb',
+    layout: false,
+    locals: @tmp_vars))
+    
+    return pdf
+  end
+  
+  def build_file_name
+    if @doc_type == 'Timesheet'
+      @tmp_vars[:timesheet].pdf_export_name
+    else
+      @doc_type
+    end
+  end
+
+  private
+  
+  def init_params(params)
+    @doc_type = params[:doc_type]
+    @tmp_vars = {}
+    case @doc_type
+    when 'Trip_request'
+      @tmp_vars[:trip] = Trip.find(params[:doc_id])
+      @tmp_vars[:trip].annotation = @tmp_vars[:trip].annotation || ''
+      @tmp_vars[:annotation_splitted] = @tmp_vars[:trip].annotation.split("\n")[0, 4]
+    when 'Holiday_request'
+      @tmp_vars[:holiday] = Holiday.find(params[:doc_id])
+    when 'Expense_request'
+      @tmp_vars[:report] = Expense.find(params[:doc_id])
+      @tmp_vars[:reason_splitted] = @tmp_vars[:report].reason.split("\n")
+    when 'Timesheet'
+      @tmp_vars[:timesheet] = TimeSheet.find(params[:doc_id])
+      @tmp_vars[:days_in_month] = []
+      @tmp_vars[:work_days] = @tmp_vars[:timesheet].work_days
+      @tmp_vars[:include_comments] = params[:include_comments] == '1'
+      # First day of month
+      day = Date.new(@tmp_vars[:timesheet].year, @tmp_vars[:timesheet].month)
+      # Iterate over all days for this month
+      while day.month == @tmp_vars[:timesheet].month
+        @tmp_vars[:days_in_month].push({
+          date: day, start: ' ', break: ' ', end: ' ',
+          duration: '0:00', notes: ' '
+        })
+        day += 1 # Select following day
+      end
+      for workday in @tmp_vars[:timesheet].work_days do
+        for day in @tmp_vars[:days_in_month] do
+          if workday.date == day[:date]
+            day[:start] = workday.start_time.strftime('%H:%M')
+            break_minutes = workday.break % 60
+            break_hours = (workday.break - break_minutes) / 60
+            day[:break] = format("%d:%02d", break_hours, break_minutes)
+            day[:end] = workday.end_time.strftime('%H:%M')
+            day[:duration] = workday.duration_hours_minutes
+            day[:notes] = workday.notes
+            day[:status] = workday.status
+          end
+        end
+      end
+      @tmp_vars[:sum] = @tmp_vars[:timesheet].sum_minutes_formatted
+    else
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/document_builder.rb
+++ b/lib/document_builder.rb
@@ -22,7 +22,7 @@ class DocumentBuilder < ActionController::Base
   
   def build_file_name
     if @doc_type == 'Timesheet'
-      file_name = @tmp_vars[:timesheet].pdf_export_name
+      file_name = @tmp_vars[:timesheet].attachment_name
     else
       file_name = @doc_type
     end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe DocumentsController, type: :controller do
     end
 
     it 'should generate a PDF file for a travel expense report application', :slow => true do
-      pending 'broken after document generation refactor - should have been broken beforehand though'
       report = FactoryGirl.create(:expense)
       params = {doc_type: 'Expense_request', doc_id: report.id}
       get :generate_pdf, params
@@ -28,7 +27,6 @@ RSpec.describe DocumentsController, type: :controller do
     end
 
     it 'should generate a PDF file for a business trip application', :slow => true do
-      pending 'broken after document generation refactor - should have been broken beforehand though'
       trip = FactoryGirl.create(:trip)
       params = {doc_type: 'Trip_request', doc_id: trip.id}
       get :generate_pdf, params

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe DocumentsController, type: :controller do
       params = {doc_type: 'Timesheet', doc_id: time_sheet.id}
       get :generate_pdf, params
       expect(response.headers['Content-Type']).to eq('application/pdf')
-      expected_content_disposition = "attachment; filename=\"#{time_sheet.pdf_export_name}.pdf\""
+      expected_content_disposition = "attachment; filename=\"#{time_sheet.attachment_name}.pdf\""
       expect(response.headers['Content-Disposition']).to eq(expected_content_disposition)
     end
   end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe DocumentsController, type: :controller do
     end
 
     it 'should generate a PDF file for a travel expense report application', :slow => true do
+      pending 'broken after document generation refactor - should have been broken beforehand though'
       report = FactoryGirl.create(:expense)
       params = {doc_type: 'Expense_request', doc_id: report.id}
       get :generate_pdf, params
@@ -27,6 +28,7 @@ RSpec.describe DocumentsController, type: :controller do
     end
 
     it 'should generate a PDF file for a business trip application', :slow => true do
+      pending 'broken after document generation refactor - should have been broken beforehand though'
       trip = FactoryGirl.create(:trip)
       params = {doc_type: 'Trip_request', doc_id: trip.id}
       get :generate_pdf, params

--- a/spec/factories/expenses.rb
+++ b/spec/factories/expenses.rb
@@ -41,6 +41,8 @@ FactoryGirl.define do
     hotel true
     general_advance 2000
     signature true
+    user_signature 'signature'
+    user_signed_at Date.today
     user
     trip
     after(:create) do |report|

--- a/spec/factories/time_sheet_factory.rb
+++ b/spec/factories/time_sheet_factory.rb
@@ -49,7 +49,11 @@ FactoryGirl.define do
       hand_in_date { Date.new(year,month) }
       status 'accepted'
       signer { contract.responsible.id }
+      wimi_signed true
       representative_signed_at { Date.new(year,month) }
+      signed true
+      user_signed_at { Date.new(year,month) }
+      user_signature ''
     end
 
   end

--- a/spec/factories/trip.rb
+++ b/spec/factories/trip.rb
@@ -7,6 +7,8 @@ FactoryGirl.define do
     date_end Date.today + 2
     days_abroad 1
     signature true
+    user_signature 'signature'
+    user_signed_at Date.today
     user
   end
 

--- a/spec/features/time_sheet/send_to_admin_spec.rb
+++ b/spec/features/time_sheet/send_to_admin_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'cancan/matchers'
 
 describe 'timesheet#show' do 
-
+  
 	context 'with an accepted time sheet' do 
 		before :each do
 			@contract = FactoryGirl.create(:contract)
@@ -10,18 +10,38 @@ describe 'timesheet#show' do
 			@user = @time_sheet.user
 			@wimi = @time_sheet.contract.responsible
 		end
-
+    
 		it 'should allow the responsible wimi to send the pdf to the admin' do
 			ability = Ability.new(@wimi)
 			expect(ability).to be_able_to(:send_to_admin, @time_sheet)
 		end
-
+    
 		it 'should have a button for sending the pdf to the admin' do
 			login_as @wimi
 			visit time_sheet_path(@time_sheet)
-
+      
 			expect(page).to have_selector(:linkhref, send_to_admin_time_sheet_path(@time_sheet))
 		end
+	end	
+end
+
+RSpec.describe TimeSheetsController, type: :controller do
+	before :each do
+    @chair = FactoryGirl.create(:chair)
+    @admin = FactoryGirl.create(:user)
+    @contract = FactoryGirl.create(:contract,chair: @chair, responsible: @admin)
+		@timesheet = FactoryGirl.create(:time_sheet_accepted, contract: @contract)
+    FactoryGirl.create(:admin, chair: @chair, user: @admin)
+    login_with @admin
 	end
-	
+  
+	context 'timesheet#send_to_admin' do
+		context 'with an accepted timesheet' do
+			it 'should send a mail to the admin' do
+        expect(Ability.new @admin).to be_able_to(:send_to_admin, @timesheet)
+				expect{ get :send_to_admin, {id: @timesheet.id} }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        expect(response).to redirect_to(time_sheet_path(@timesheet))
+			end
+		end
+	end
 end

--- a/spec/features/time_sheet/send_to_admin_spec.rb
+++ b/spec/features/time_sheet/send_to_admin_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+require 'cancan/matchers'
+
+describe 'timesheet#show' do 
+
+	context 'with an accepted time sheet' do 
+		before :each do
+			@contract = FactoryGirl.create(:contract)
+			@time_sheet = FactoryGirl.create(:time_sheet_accepted, contract: @contract)
+			@user = @time_sheet.user
+			@wimi = @time_sheet.contract.responsible
+		end
+
+		it 'should allow the responsible wimi to send the pdf to the admin' do
+			ability = Ability.new(@wimi)
+			expect(ability).to be_able_to(:send_to_admin, @time_sheet)
+		end
+
+		it 'should have a button for sending the pdf to the admin' do
+			login_as @wimi
+			visit time_sheet_path(@time_sheet)
+
+			expect(page).to have_selector(:linkhref, send_to_admin_time_sheet_path(@time_sheet))
+		end
+	end
+	
+end

--- a/spec/features/time_sheet/send_to_admin_spec.rb
+++ b/spec/features/time_sheet/send_to_admin_spec.rb
@@ -1,50 +1,48 @@
 require 'rails_helper'
 require 'cancan/matchers'
 
-describe 'timesheet#show' do 
-  
-	context 'with an accepted time sheet' do 
-		before :each do
-			@contract = FactoryGirl.create(:contract)
-			@time_sheet = FactoryGirl.create(:time_sheet_accepted, contract: @contract)
-			@user = @time_sheet.user
-			@wimi = @time_sheet.contract.responsible
-		end
-    
-		it 'should allow the responsible wimi to send the pdf to the admin' do
-			ability = Ability.new(@wimi)
-			expect(ability).to be_able_to(:send_to_admin, @time_sheet)
-		end
-    
-		it 'should have a button for sending the pdf to the admin' do
-			login_as @wimi
-			visit time_sheet_path(@time_sheet)
-      
-			expect(page).to have_selector(:linkhref, send_to_admin_time_sheet_path(@time_sheet))
-		end
-	end	
+describe 'timesheet#show' do
+  context 'with an accepted time sheet' do
+    before :each do
+      @contract = FactoryGirl.create(:contract)
+      @time_sheet = FactoryGirl.create(:time_sheet_accepted, contract: @contract)
+      @user = @time_sheet.user
+      @wimi = @time_sheet.contract.responsible
+    end
+
+    it 'should allow the responsible wimi to send the pdf to the admin' do
+      ability = Ability.new(@wimi)
+      expect(ability).to be_able_to(:send_to_admin, @time_sheet)
+    end
+
+    it 'should have a button for sending the pdf to the admin' do
+      login_as @wimi
+      visit time_sheet_path(@time_sheet)
+      expect(page).to have_selector(:linkhref, send_to_admin_time_sheet_path(@time_sheet))
+    end
+  end
 end
 
 RSpec.describe TimeSheetsController, type: :controller do
-	before :each do
+  before :each do
     @chair = FactoryGirl.create(:chair)
     @admin = FactoryGirl.create(:user)
-	@contract = FactoryGirl.create(:contract,chair: @chair)
-	@wimi = @contract.responsible
-	@timesheet = FactoryGirl.create(:time_sheet_accepted, contract: @contract)
-	FactoryGirl.create(:admin, chair: @chair, user: @admin)
-	@admin.update(event_settings: [Event.types[:time_sheet_admin_mail]])
-	@admin.reload
+    @contract = FactoryGirl.create(:contract,chair: @chair)
+    @wimi = @contract.responsible
+    @timesheet = FactoryGirl.create(:time_sheet_accepted, contract: @contract)
+    FactoryGirl.create(:admin, chair: @chair, user: @admin)
+    @admin.update(event_settings: [Event.types[:time_sheet_admin_mail]])
+    @admin.reload
     login_with @wimi
-	end
-  
-	context 'timesheet#send_to_admin' do
-		context 'with an accepted timesheet' do
-			it 'should send a mail to the admin' do
-        		expect(Ability.new @wimi).to be_able_to(:send_to_admin, @timesheet)
-				expect{ get :send_to_admin, {id: @timesheet.id} }.to change(ActionMailer::Base.deliveries, :count).by(1)
-        		expect(response).to redirect_to(time_sheet_path(@timesheet))
-			end
-		end
-	end
+  end
+
+  context 'timesheet#send_to_admin' do
+    context 'with an accepted timesheet' do
+      it 'should send a mail to the admin' do
+        expect(Ability.new @wimi).to be_able_to(:send_to_admin, @timesheet)
+        expect{ get :send_to_admin, {id: @timesheet.id} }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        expect(response).to redirect_to(time_sheet_path(@timesheet))
+      end
+    end
+  end
 end

--- a/spec/features/time_sheet/send_to_admin_spec.rb
+++ b/spec/features/time_sheet/send_to_admin_spec.rb
@@ -29,18 +29,21 @@ RSpec.describe TimeSheetsController, type: :controller do
 	before :each do
     @chair = FactoryGirl.create(:chair)
     @admin = FactoryGirl.create(:user)
-    @contract = FactoryGirl.create(:contract,chair: @chair, responsible: @admin)
-		@timesheet = FactoryGirl.create(:time_sheet_accepted, contract: @contract)
-    FactoryGirl.create(:admin, chair: @chair, user: @admin)
-    login_with @admin
+	@contract = FactoryGirl.create(:contract,chair: @chair)
+	@wimi = @contract.responsible
+	@timesheet = FactoryGirl.create(:time_sheet_accepted, contract: @contract)
+	FactoryGirl.create(:admin, chair: @chair, user: @admin)
+	@admin.update(event_settings: [Event.types[:time_sheet_admin_mail]])
+	@admin.reload
+    login_with @wimi
 	end
   
 	context 'timesheet#send_to_admin' do
 		context 'with an accepted timesheet' do
 			it 'should send a mail to the admin' do
-        expect(Ability.new @admin).to be_able_to(:send_to_admin, @timesheet)
+        		expect(Ability.new @wimi).to be_able_to(:send_to_admin, @timesheet)
 				expect{ get :send_to_admin, {id: @timesheet.id} }.to change(ActionMailer::Base.deliveries, :count).by(1)
-        expect(response).to redirect_to(time_sheet_path(@timesheet))
+        		expect(response).to redirect_to(time_sheet_path(@timesheet))
 			end
 		end
 	end

--- a/spec/features/user/update_event_settings_spec.rb
+++ b/spec/features/user/update_event_settings_spec.rb
@@ -30,6 +30,13 @@ describe 'updating event preferences' do
     @user.reload
     expect(@user.event_settings).to eq([])
   end
+
+  it 'should not show events that have email disabled' do
+    visit edit_user_path(@user)
+    Event::NOMAIL.each do |type|
+      expect(page).to_not have_content(I18n.t("event.user_friendly_name.#{type}"))
+    end
+  end
 end
 
 describe 'a new users event settings' do

--- a/spec/features/user/update_event_settings_spec.rb
+++ b/spec/features/user/update_event_settings_spec.rb
@@ -33,7 +33,7 @@ describe 'updating event preferences' do
 
   it 'should not show events that have email disabled' do
     visit edit_user_path(@user)
-    Event::NOMAIL.each do |type|
+    Event.NOMAIL.each do |type|
       expect(page).to_not have_content(I18n.t("event.user_friendly_name.#{type}"))
     end
   end

--- a/spec/mailers/event_mails_spec.rb
+++ b/spec/mailers/event_mails_spec.rb
@@ -42,8 +42,9 @@ RSpec.describe Event, type: :model do
     end
 
     it 'not sent on creation if the event has mail disabled' do
-      pending 're-enable when NOMAIL is no longer empty'
-      @event.type = :time_sheet_admin_mail
+      # enum mapping is stored in hash, thus first twice
+      allow(Event).to receive(:NOMAIL) {[Event.types.first.first]}
+      @event.type = Event.types.first.first
       expect(@event).to have_mail_disabled
       expect { @event.save! }.to change(ActionMailer::Base.deliveries, :count).by(0)
     end

--- a/spec/mailers/event_mails_spec.rb
+++ b/spec/mailers/event_mails_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Event, type: :model do
     end
 
     it 'not sent on creation if the event has mail disabled' do
+      pending 're-enable when NOMAIL is no longer empty'
       @event.type = :time_sheet_admin_mail
       expect(@event).to have_mail_disabled
       expect { @event.save! }.to change(ActionMailer::Base.deliveries, :count).by(0)

--- a/spec/mailers/event_mails_spec.rb
+++ b/spec/mailers/event_mails_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Event, type: :model do
     end
   end
 
-  context 'mails are sent' do
+  context 'mails are' do
     before :each do
       @user = FactoryGirl.create(:user)
       @user2 = FactoryGirl.create(:user)
@@ -36,9 +36,15 @@ RSpec.describe Event, type: :model do
       @user2.update(event_settings: [@event.type_id])
     end
 
-    it 'on event creation' do
+    it 'sent on event creation' do
       expect(@event.users_want_mail).to include(@user2)
       expect { @event.save! }.to change(ActionMailer::Base.deliveries, :count).by(1)
+    end
+
+    it 'not sent on creation if the event has mail disabled' do
+      @event.type = :time_sheet_admin_mail
+      expect(@event).to have_mail_disabled
+      expect { @event.save! }.to change(ActionMailer::Base.deliveries, :count).by(0)
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -83,15 +83,15 @@ RSpec.describe Event, type: :model do
     end
 
     it 'returns false if the type is not contained in NOMAIL' do
-      expect(Event::NOMAIL).to_not include(@event.type)
+      expect(Event.NOMAIL).to_not include(@event.type)
       expect(@event).not_to have_mail_disabled
     end
 
     it 'returns true if the type is contained in NOMAIL' do
-      pending 're-enable when NOMAIL is no longer empty'
-      @event.update(type: :time_sheet_admin_mail)
+      allow(Event).to receive(:NOMAIL) {[Event.types.first.first]}      
+      @event.update(type: Event.types.first.first)
       @event.reload
-      expect(Event::NOMAIL).to include(@event.type)
+      expect(Event.NOMAIL).to include(@event.type)
       expect(@event).to have_mail_disabled
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -72,7 +72,26 @@ RSpec.describe Event, type: :model do
       "contract_create"=>9,
       "contract_extend"=>10,
       "time_sheet_closed"=>11,
+      "time_sheet_admin_mail"=>12,
     }
     expect(Event.types).to eq(original_enum_order)
+  end
+
+  context 'has_mail_disabled?' do
+    before :each do
+      @event = FactoryGirl.create(:event)
+    end
+
+    it 'returns false if the type is not contained in NOMAIL' do
+      expect(Event::NOMAIL).to_not include(@event.type)
+      expect(@event).not_to have_mail_disabled
+    end
+
+    it 'returns true if the type is contained in NOMAIL' do
+      @event.update(type: :time_sheet_admin_mail)
+      @event.reload
+      expect(Event::NOMAIL).to include(@event.type)
+      expect(@event).to have_mail_disabled
+    end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe Event, type: :model do
     end
 
     it 'returns true if the type is contained in NOMAIL' do
+      pending 're-enable when NOMAIL is no longer empty'
       @event.update(type: :time_sheet_admin_mail)
       @event.reload
       expect(Event::NOMAIL).to include(@event.type)

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -59,4 +59,22 @@ RSpec.describe 'users/show', type: :view do
 #    expect(page).to_not have_content(t('users.show.user_data'))
 #    expect(page).to have_content(t('users.show.password'))
 #  end
+
+  context 'event settings' do
+    before :each do
+      visit user_path(@user)
+    end
+
+    it 'are displayed for event types that are mail enabled' do
+      Event.mail_enabled_types.each do |type,v|
+        expect(page).to have_content(I18n.t("event.user_friendly_name.#{type}"))
+      end
+    end
+
+    it 'are hidden for event types that are not mail enabled' do
+      Event::NOMAIL.each do |type|
+        expect(page).not_to have_content(I18n.t("event.user_friendly_name.#{type}"))
+      end
+    end
+  end
 end

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'users/show', type: :view do
     end
 
     it 'are hidden for event types that are not mail enabled' do
-      Event::NOMAIL.each do |type|
+      Event.NOMAIL.each do |type|
         expect(page).not_to have_content(I18n.t("event.user_friendly_name.#{type}"))
       end
     end


### PR DESCRIPTION
see #584

a refactoring of the documents generation was necessary.
I created a helper class `DocumentBuilder` in `/lib/document_builder` that uses the old generation code.
Because we are using `html.erb` templates to define the pdfs the builder had to inherit from `ActionController::Base`.
This Builder is then instantiated on demand and builds the pdfs.

I also adapted the old `documents_controller` to use the builder. This broke two old tests concerning trips and expense reports. I looked through the code and it appears that it should have been broken beforehand, so if you have an idea what happened let me know.